### PR TITLE
[#158456560] Add a lot of metrics to the collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ integration:
 	ginkgo -v -r ci/blackbox
 
 start_postgres_docker:
-	docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
+	docker run --rm -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
 
 stop_postgres_docker:
 	docker stop postgres

--- a/example_config.json
+++ b/example_config.json
@@ -1,10 +1,10 @@
 {
-	"log_level": "INFO",
+	"log_level": "DEBUG",
 	"aws": {
 		"region": "eu-west-1"
 	},
 	"rds_broker": {
-		"broker_name": "mybroker",
+		"broker_name": "hector",
 		"db_prefix": "rdsbroker",
 		"master_password_seed": "abc123"
 	},

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -32,6 +32,13 @@ var metricNamesToLabels = map[string]string{
 	"WriteIOPS":                 "write_iops",
 	"WriteLatency":              "write_latency",
 	"WriteThroughput":           "write_rate",
+	// More fancy metrics
+	"ReplicaLag":                "replica_lag",
+	"ReplicationSlotDiskUsage":  "replica_slot_disk_usage",
+	"OldestReplicationSlotLag":  "replication_lag",
+	"MaximumUsedTransactionIDs": "max_used_transaction_ids",
+	"TransactionLogsDiskUsage":  "transaction_logs_disk_usage",
+	"TransactionLogsGeneration": "transaction_logs_generation",
 }
 
 // NewCloudWatchCollectorDriver ...

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -128,6 +128,9 @@ func (cw *CloudWatchCollector) Collect() ([]metrics.Metric, error) {
 				Timestamp: aws.TimeValue(d.Timestamp).UnixNano(),
 				Value:     aws.Float64Value(d.Average),
 				Unit:      strings.ToLower(*d.Unit),
+				Tags: map[string]string{
+					"source": "cloudwatch",
+				},
 			})
 		} else {
 			cw.logger.Debug("no_metrics_retrieved")

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -17,7 +17,21 @@ import (
 )
 
 var metricNamesToLabels = map[string]string{
-	"CPUUtilization": "cpu",
+	"CPUUtilization":            "cpu",
+	"CPUCreditUsage":            "cpu_credit_usage",
+	"CPUCreditBalance":          "cpu_credit_balance",
+	"FreeableMemory":            "freeable_memory",
+	"FreeStorageSpace":          "free_storage_space",
+	"SwapUsage":                 "swap_usage",
+	"NetworkReceiveThroughput":  "network_receive_rate",
+	"NetworkTransmitThroughput": "network_transmit_rate",
+	"DiskQueueDepth":            "disk_queue_depth",
+	"ReadIOPS":                  "read_iops",
+	"ReadLatency":               "read_latency",
+	"ReadThroughput":            "read_rate",
+	"WriteIOPS":                 "write_iops",
+	"WriteLatency":              "write_latency",
+	"WriteThroughput":           "write_rate",
 }
 
 // NewCloudWatchCollectorDriver ...

--- a/pkg/collector/cloudwatch_collector_test.go
+++ b/pkg/collector/cloudwatch_collector_test.go
@@ -93,6 +93,7 @@ var _ = Describe("cloudwatch_collector", func() {
 			Expect(data).NotTo(BeEmpty())
 			Expect(data[0].Unit).To(Equal("second"))
 			Expect(data[0].Value).To(Equal(3.0))
+			Expect(data[0].Tags).To(HaveKeyWithValue("source", "cloudwatch"))
 		})
 		It("should preserve the timestamp", func() {
 			metricTime := time.Now().Add(-1 * time.Hour)

--- a/pkg/collector/cloudwatch_collector_test.go
+++ b/pkg/collector/cloudwatch_collector_test.go
@@ -90,7 +90,7 @@ var _ = Describe("cloudwatch_collector", func() {
 			data, err := collector.Collect()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).NotTo(BeNil())
-			Expect(data).To(HaveLen(1))
+			Expect(data).NotTo(BeEmpty())
 			Expect(data[0].Unit).To(Equal("second"))
 			Expect(data[0].Value).To(Equal(3.0))
 		})
@@ -111,7 +111,7 @@ var _ = Describe("cloudwatch_collector", func() {
 			data, err := collector.Collect()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data).NotTo(BeNil())
-			Expect(data).To(HaveLen(1))
+			Expect(data).NotTo(BeEmpty())
 			Expect(data[0].Timestamp).To(Equal(metricTime.UnixNano()))
 		})
 		It("should not fail if there are no datapoints", func() {

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -57,7 +57,6 @@ var postgresMetricQueries = []MetricQuery{
 		Query: `
 			SELECT
 				COALESCE(seq_scan, 0) as seq_scan,
-				COALESCE(idx_scan, 0) as idx_scan,
 				relname as table_name,
 				current_database() as dbname
 			FROM pg_stat_user_tables
@@ -67,6 +66,18 @@ var postgresMetricQueries = []MetricQuery{
 				Key:  "seq_scan",
 				Unit: "scan",
 			},
+		},
+	},
+	MetricQuery{
+		Query: `
+			SELECT
+				idx_scan,
+				relname as table_name,
+				indexrelname as index_name,
+				current_database() as dbname
+			FROM pg_stat_user_indexes
+		`,
+		Metrics: []MetricQueryMeta{
 			{
 				Key:  "idx_scan",
 				Unit: "scan",

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -165,6 +165,20 @@ var postgresMetricQueries = []MetricQuery{
 			},
 		},
 	},
+	MetricQuery{
+		Query: `
+			SELECT
+				EXTRACT(epoch FROM MAX(now() - xact_start))::INT as max_tx_age
+			FROM pg_stat_activity
+      WHERE state IN ('idle in transaction', 'active')
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "max_tx_age",
+				Unit: "s",
+			},
+		},
+	},
 }
 
 // NewPostgresMetricsCollectorDriver ...

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -55,6 +55,24 @@ var postgresMetricQueries = []MetricQuery{
 	MetricQuery{
 		Query: `
 			SELECT
+				pg_table_size(C.oid) as table_size,
+				relname as table_name,
+				current_database() as dbname
+			FROM pg_class C LEFT JOIN pg_namespace N
+			ON (N.oid = C.relnamespace)
+			WHERE nspname NOT IN ('pg_catalog', 'information_schema')
+			AND nspname !~ '^pg_toast' AND relkind IN ('r')
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "table_size",
+				Unit: "byte",
+			},
+		},
+	},
+	MetricQuery{
+		Query: `
+			SELECT
 				deadlocks,
 				current_database() as dbname
 			FROM pg_stat_database

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -73,7 +73,14 @@ var postgresMetricQueries = []MetricQuery{
 	MetricQuery{
 		Query: `
 			SELECT
-				deadlocks,
+				deadlocks as deadlocks,
+				xact_commit as commits,
+				xact_rollback as rollbacks,
+				blks_read as blocks_read,
+				blks_hit as blocks_hit,
+				blk_read_time as read_time,
+				blk_write_time as write_time,
+				temp_bytes as temp_bytes,
 				current_database() as dbname
 			FROM pg_stat_database
 			WHERE datname = current_database()
@@ -82,6 +89,34 @@ var postgresMetricQueries = []MetricQuery{
 			{
 				Key:  "deadlocks",
 				Unit: "lock",
+			},
+			{
+				Key:  "commits",
+				Unit: "tx",
+			},
+			{
+				Key:  "rollbacks",
+				Unit: "tx",
+			},
+			{
+				Key:  "blocks_read",
+				Unit: "block",
+			},
+			{
+				Key:  "blocks_hit",
+				Unit: "block",
+			},
+			{
+				Key:  "read_time",
+				Unit: "ms",
+			},
+			{
+				Key:  "write_time",
+				Unit: "ms",
+			},
+			{
+				Key:  "temp_bytes",
+				Unit: "byte",
 			},
 		},
 	},

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -53,6 +53,26 @@ var postgresMetricQueries = []MetricQuery{
 			},
 		},
 	},
+	MetricQuery{
+		Query: `
+			SELECT
+				COALESCE(seq_scan, 0) as seq_scan,
+				COALESCE(idx_scan, 0) as idx_scan,
+				relname as table_name,
+				current_database() as dbname
+			FROM pg_stat_user_tables
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "seq_scan",
+				Unit: "scan",
+			},
+			{
+				Key:  "idx_scan",
+				Unit: "scan",
+			},
+		},
+	},
 }
 
 // NewPostgresMetricsCollectorDriver ...

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -11,11 +11,30 @@ import (
 
 var postgresMetricQueries = []MetricQuery{
 	MetricQuery{
-		Query: "SELECT CAST (SUM(numbackends) AS DOUBLE PRECISION) AS connections FROM pg_stat_database",
+		Query: `
+			SELECT
+				SUM(numbackends) AS connections
+			FROM pg_stat_database
+		`,
 		Metrics: []MetricQueryMeta{
 			{
 				Key:  "connections",
 				Unit: "conn",
+			},
+		},
+	},
+	MetricQuery{
+		Query: `
+			SELECT
+				pg_database_size(pg_database.datname) as dbsize,
+				current_database() as dbname
+			FROM pg_database
+			WHERE datname = current_database()
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "dbsize",
+				Unit: "byte",
 			},
 		},
 	},

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -26,6 +26,20 @@ var postgresMetricQueries = []MetricQuery{
 	MetricQuery{
 		Query: `
 			SELECT
+					setting::float as max_connections
+			FROM pg_settings
+			WHERE name = 'max_connections'
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "max_connections",
+				Unit: "conn",
+			},
+		},
+	},
+	MetricQuery{
+		Query: `
+			SELECT
 				pg_database_size(pg_database.datname) as dbsize,
 				current_database() as dbname
 			FROM pg_database

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -151,6 +151,20 @@ var postgresMetricQueries = []MetricQuery{
 			},
 		},
 	},
+	MetricQuery{
+		Query: `
+			SELECT
+				count(distinct pid) as blocked_connections
+			FROM pg_locks
+			WHERE granted = false
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "blocked_connections",
+				Unit: "conn",
+			},
+		},
+	},
 }
 
 // NewPostgresMetricsCollectorDriver ...

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -38,6 +38,21 @@ var postgresMetricQueries = []MetricQuery{
 			},
 		},
 	},
+	MetricQuery{
+		Query: `
+			SELECT
+				deadlocks,
+				current_database() as dbname
+			FROM pg_stat_database
+			WHERE datname = current_database()
+		`,
+		Metrics: []MetricQueryMeta{
+			{
+				Key:  "deadlocks",
+				Unit: "lock",
+			},
+		},
+	},
 }
 
 // NewPostgresMetricsCollectorDriver ...

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -62,7 +62,7 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 			INSERT INTO
 				films(title, date_prod, kind, len)
 			VALUES
-				('The Shawshank Redemption', '1995-02-17', 'drama', 142)
+				('The Shawshaxxxxxiank Redemption', '1995-02-17', 'drama', 142)
 		`)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = testDBConn.Exec(`
@@ -186,7 +186,7 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric.Tags).To(HaveKeyWithValue("table_name", "films"))
 	})
 
-	Context("deadlocks", func() {
+	FContext("pg_stat_database", func() {
 		It("can collect the database deadlocks", func() {
 			metric := getMetricByKey(collectedMetrics, "deadlocks")
 			Expect(metric).ToNot(BeNil())
@@ -239,6 +239,50 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 				2*time.Second,
 				500*time.Millisecond,
 			).Should(BeNumerically("==", 1))
+		})
+
+		It("can collect number of commit and rollback transactions", func() {
+			metric := getMetricByKey(collectedMetrics, "commits")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("tx"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+			metric = getMetricByKey(collectedMetrics, "rollbacks")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("tx"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+		})
+
+		It("can collect number of blocks read/hit and write/read times", func() {
+			metric := getMetricByKey(collectedMetrics, "blocks_read")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("block"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+			metric = getMetricByKey(collectedMetrics, "blocks_hit")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("block"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+			metric = getMetricByKey(collectedMetrics, "read_time")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("ms"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+			metric = getMetricByKey(collectedMetrics, "write_time")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("ms"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+		})
+
+		It("can collect the bytes in temporary files", func() {
+			metric := getMetricByKey(collectedMetrics, "temp_bytes")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("byte"))
+			Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
 		})
 	})
 

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -177,6 +177,15 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
 	})
 
+	It("can collect the table sizes", func() {
+		metric := getMetricByKey(collectedMetrics, "table_size")
+		Expect(metric).ToNot(BeNil())
+		Expect(metric.Value).To(BeNumerically(">=", 1))
+		Expect(metric.Unit).To(Equal("byte"))
+		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
+		Expect(metric.Tags).To(HaveKeyWithValue("table_name", "films"))
+	})
+
 	Context("deadlocks", func() {
 		It("can collect the database deadlocks", func() {
 			metric := getMetricByKey(collectedMetrics, "deadlocks")

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -162,6 +162,13 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		)
 	})
 
+	It("can collect the number of maximum connections", func() {
+		metric := getMetricByKey(collectedMetrics, "max_connections")
+		Expect(metric).ToNot(BeNil())
+		Expect(metric.Value).To(BeNumerically(">=", 10))
+		Expect(metric.Unit).To(Equal("conn"))
+	})
+
 	It("can collect the database size", func() {
 		metric := getMetricByKey(collectedMetrics, "dbsize")
 		Expect(metric).ToNot(BeNil())

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -242,6 +242,7 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric.Unit).To(Equal("scan"))
 		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
 		Expect(metric.Tags).To(HaveKeyWithValue("table_name", "films"))
+		Expect(metric.Tags).To(HaveKeyWithValue("index_name", "title_idx"))
 
 		initialIdxScanValue := metric.Value
 

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -2,10 +2,11 @@ package collector
 
 import (
 	"database/sql"
+	"fmt"
+	"regexp"
 	"time"
 
 	_ "github.com/lib/pq"
-
 	"github.com/stretchr/testify/mock"
 
 	. "github.com/onsi/ginkgo"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo/fakebrokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/utils"
 )
 
 var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
@@ -21,10 +23,91 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		brokerInfo             *fakebrokerinfo.FakeBrokerInfo
 		metricsCollectorDriver MetricsCollectorDriver
 		metricsCollector       MetricsCollector
+		collectedMetrics       []metrics.Metric
+		testDBName             string
+		testDBConnectionString string
+		testDBConn             *sql.DB
 	)
+
 	BeforeEach(func() {
+		testDBName = utils.RandomString(10)
+		testDBConnectionString = injectDBName(postgresTestDatabaseConnectionURL, testDBName)
+
+		mainDBConn, err := sql.Open("postgres", postgresTestDatabaseConnectionURL)
+		defer mainDBConn.Close()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = mainDBConn.Exec(fmt.Sprintf("CREATE DATABASE %s", testDBName))
+		Expect(err).NotTo(HaveOccurred())
+
+		testDBConn, err = sql.Open("postgres", testDBConnectionString)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = testDBConn.Exec(`
+			CREATE TABLE films (
+					id          SERIAL NOT NULL,
+					title       varchar(40) NOT NULL,
+					date_prod   date,
+					kind        varchar(10),
+					len         integer
+			)
+		`)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = testDBConn.Exec(`
+			INSERT INTO
+				films(title, date_prod, kind, len)
+			VALUES
+				('The Shawshank Redemption', '1995-02-17', 'drama', 142)
+		`)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = testDBConn.Exec(`
+			INSERT INTO
+				films(title, date_prod, kind, len)
+			VALUES
+				('Code Name: K.O.Z.', '2015-02-13', 'crime', 114)
+		`)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		testDBConn.Close()
+		dbConn, err := sql.Open("postgres", postgresTestDatabaseConnectionURL)
+		defer dbConn.Close()
+		Expect(err).NotTo(HaveOccurred())
+		// Kill all connections to this DB, as sql.DB keeps a pool and it
+		// does not close all, preventing the DROP DATABASE from working.
+		// FIXME: Why I cannot use a Prepare parametrized query here??
+		_, err = dbConn.Query(fmt.Sprintf(`
+			SELECT pg_terminate_backend(pg_stat_activity.pid)
+			FROM pg_stat_activity
+			WHERE datname = '%s'
+		`, testDBName))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = dbConn.Query(fmt.Sprintf("DROP DATABASE %s", testDBName))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+		var err error
 		brokerInfo = &fakebrokerinfo.FakeBrokerInfo{}
 		metricsCollectorDriver = NewPostgresMetricsCollectorDriver(brokerInfo, logger)
+
+		brokerInfo.On(
+			"ConnectionString", mock.Anything,
+		).Return(
+			testDBConnectionString, nil,
+		)
+		By("Creating a new collector")
+		metricsCollector, err = metricsCollectorDriver.NewCollector("instance-guid1")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Retrieving initial metrics")
+		collectedMetrics, err = metricsCollector.Collect()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := metricsCollector.Close()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("returns the right metricsCollectorDriver name", func() {
@@ -33,20 +116,8 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 
 	It("can collect the number of connections", func() {
 		var err error
-		brokerInfo.On(
-			"ConnectionString", mock.Anything,
-		).Return(
-			postgresTestDatabaseConnectionURL, nil,
-		)
 
-		By("Creating a new collector")
-		metricsCollector, err = metricsCollectorDriver.NewCollector("instance-guid1")
-		Expect(err).NotTo(HaveOccurred())
-
-		collectedMetrics, err := metricsCollector.Collect()
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Retrieving initial metrics")
+		By("Checking initial number of connections")
 		metric := getMetricByKey(collectedMetrics, "connections")
 		Expect(metric).ToNot(BeNil())
 		Expect(metric.Value).To(BeNumerically(">=", 1))
@@ -82,6 +153,14 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		}, 2*time.Second).Should(
 			BeNumerically("<=", initialConnections+5),
 		)
+	})
+
+	It("can collect the database size", func() {
+		metric := getMetricByKey(collectedMetrics, "dbsize")
+		Expect(metric).ToNot(BeNil())
+		Expect(metric.Value).To(BeNumerically(">=", 1))
+		Expect(metric.Unit).To(Equal("byte"))
+		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
 	})
 })
 
@@ -119,3 +198,24 @@ func getMetricByKey(collectedMetrics []metrics.Metric, key string) *metrics.Metr
 	}
 	return nil
 }
+
+// Replaces the DB name in a postgres DB connection string
+func injectDBName(connectionString, newDBName string) string {
+	re := regexp.MustCompile("(.*:[0-9]+)[^?]*([?].*)?$")
+	return re.ReplaceAllString(connectionString, fmt.Sprintf("$1/%s$2", newDBName))
+}
+
+var _ = Describe("injectDBName", func() {
+	It("replaces the db name", func() {
+		Expect(
+			injectDBName("postgresql://postgres@localhost:5432/foo?sslmode=disable", "mydb"),
+		).To(Equal(
+			"postgresql://postgres@localhost:5432/mydb?sslmode=disable",
+		))
+		Expect(
+			injectDBName("postgresql://postgres@localhost:5432?sslmode=disable", "mydb"),
+		).To(Equal(
+			"postgresql://postgres@localhost:5432/mydb?sslmode=disable",
+		))
+	})
+})

--- a/pkg/collector/sql_collector.go
+++ b/pkg/collector/sql_collector.go
@@ -152,6 +152,9 @@ func queryToMetrics(db *sql.DB, mq MetricQuery) ([]metrics.Metric, error) {
 				Key:   m.Key,
 				Unit:  m.Unit,
 				Value: v,
+				Tags: map[string]string{
+					"source": "sql",
+				},
 			})
 		}
 	}

--- a/pkg/collector/sql_collector.go
+++ b/pkg/collector/sql_collector.go
@@ -100,30 +100,49 @@ func (mc *sqlMetricsCollector) Close() error {
 
 // Helpers
 
-// getRowDataAsMap Returns a sql.Rows row as a map of column => float64 value
-func getRowDataAsMap(rows *sql.Rows) (map[string]float64, error) {
-	returnData := make(map[string]float64)
+// getRowDataAsMaps Returns a sql.Rows row and returns two maps with values
+// as map[string]float64 or tags as map[string]string.
+//
+// Values should be returned as the first columns. You must pass the expected number
+// of values in the query.
+//
+func getRowDataAsMaps(numberOfValues int, rows *sql.Rows) (valuesMap map[string]float64, tagsMap map[string]string, err error) {
+	valuesMap = make(map[string]float64)
+	tagsMap = make(map[string]string)
 
 	columnNames, err := rows.Columns()
 	if err != nil {
-		return returnData, err
+		return valuesMap, tagsMap, err
 	}
 
-	var columnData = make([]float64, len(columnNames))
+	if len(columnNames) < numberOfValues {
+		return valuesMap, tagsMap, fmt.Errorf("Expected %d values but the row only has %v columns", numberOfValues, len(columnNames))
+	}
+
+	valuesData := make([]float64, numberOfValues)
+	tagsData := make([]string, len(columnNames)-numberOfValues)
 	var scanArgs = make([]interface{}, len(columnNames))
-	for i := range columnData {
-		scanArgs[i] = &columnData[i]
+	for i := range scanArgs {
+		if i < numberOfValues {
+			scanArgs[i] = &valuesData[i]
+		} else {
+			scanArgs[i] = &tagsData[i-numberOfValues]
+		}
+
 	}
 	err = rows.Scan(scanArgs...)
 	if err != nil {
-		return returnData, err
+		return valuesMap, tagsMap, err
 	}
 
-	for i, value := range columnData {
-		returnData[columnNames[i]] = value
+	for i, v := range valuesData {
+		valuesMap[columnNames[i]] = v
+	}
+	for i, v := range tagsData {
+		tagsMap[columnNames[numberOfValues+i]] = v
 	}
 
-	return returnData, nil
+	return valuesMap, tagsMap, nil
 }
 
 // queryToMetrics Executes the given query and retunrs the result as
@@ -137,10 +156,11 @@ func queryToMetrics(db *sql.DB, mq MetricQuery) ([]metrics.Metric, error) {
 
 	rowMetrics := []metrics.Metric{}
 	for rows.Next() {
-		rowMap, err := getRowDataAsMap(rows)
+		rowMap, tags, err := getRowDataAsMaps(len(mq.Metrics), rows)
 		if err != nil {
 			return nil, err
 		}
+		tags["source"] = "sql"
 
 		for _, m := range mq.Metrics {
 			v, ok := rowMap[m.Key]
@@ -152,9 +172,7 @@ func queryToMetrics(db *sql.DB, mq MetricQuery) ([]metrics.Metric, error) {
 				Key:   m.Key,
 				Unit:  m.Unit,
 				Value: v,
-				Tags: map[string]string{
-					"source": "sql",
-				},
+				Tags:  tags,
 			})
 		}
 	}

--- a/pkg/collector/sql_collector_test.go
+++ b/pkg/collector/sql_collector_test.go
@@ -155,11 +155,12 @@ var _ = Describe("sql_collector", func() {
 		It("can collect all metrics from multiple queries", func() {
 			collectedMetrics, err := collector.Collect()
 			Expect(err).NotTo(HaveOccurred())
+			expectedTags := map[string]string{"source": "sql"}
 			Expect(collectedMetrics).To(ConsistOf(
-				metrics.Metric{Key: "foo", Value: 1, Unit: "b"},
-				metrics.Metric{Key: "bar", Value: 2, Unit: "s"},
-				metrics.Metric{Key: "baz", Value: 3, Unit: "conn"},
-				metrics.Metric{Key: "foo2", Value: 1, Unit: "gauge"},
+				metrics.Metric{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
+				metrics.Metric{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},
+				metrics.Metric{Key: "baz", Value: 3, Unit: "conn", Tags: expectedTags},
+				metrics.Metric{Key: "foo2", Value: 1, Unit: "gauge", Tags: expectedTags},
 			))
 		})
 
@@ -252,10 +253,11 @@ var _ = Describe("helpers", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(rowMetrics)).To(Equal(3))
+			expectedTags := map[string]string{"source": "sql"}
 			Expect(rowMetrics).To(Equal([]metrics.Metric{
-				{Key: "foo", Value: 1, Unit: "b"},
-				{Key: "bar", Value: 2, Unit: "s"},
-				{Key: "baz", Value: 3, Unit: "conn"},
+				{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
+				{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},
+				{Key: "baz", Value: 3, Unit: "conn", Tags: expectedTags},
 			}))
 		})
 	})

--- a/pkg/collector/sql_collector_test.go
+++ b/pkg/collector/sql_collector_test.go
@@ -51,6 +51,12 @@ var testQueries = []MetricQuery{
 			{Key: "foo2", Unit: "gauge"},
 		},
 	},
+	{
+		Query: "SELECT 1 AS foo WHERE 1 = 2",
+		Metrics: []MetricQueryMeta{
+			{Key: "foo", Unit: "gauge"},
+		},
+	},
 }
 
 var _ = Describe("sql_collector", func() {
@@ -324,6 +330,12 @@ var _ = Describe("helpers", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("converting driver.Value type")))
+		})
+
+		It("should not error when query doesn't return any row", func() {
+			_, err := queryToMetrics(dbConn, testQueries[5])
+
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should succeed to obtain metrics from query", func() {

--- a/pkg/collector/sql_collector_test.go
+++ b/pkg/collector/sql_collector_test.go
@@ -16,7 +16,14 @@ import (
 
 var testQueries = []MetricQuery{
 	{
-		Query: "SELECT 1::integer as foo, '2'::varchar as bar, 3::double precision as baz",
+		Query: `
+			SELECT
+				1::integer as foo,
+				'2'::varchar as bar,
+				3::double precision as baz,
+				'val1' as tag1,
+				'val2' as tag2
+		`,
 		Metrics: []MetricQueryMeta{
 			{Key: "foo", Unit: "b"},
 			{Key: "bar", Unit: "s"},
@@ -39,7 +46,10 @@ var testQueries = []MetricQuery{
 		Query: "SELECT * FROM hell",
 	},
 	{
-		Query: "SELECT 'Hello World'",
+		Query: "SELECT 'Hello World' as foo2",
+		Metrics: []MetricQueryMeta{
+			{Key: "foo2", Unit: "gauge"},
+		},
 	},
 }
 
@@ -155,12 +165,13 @@ var _ = Describe("sql_collector", func() {
 		It("can collect all metrics from multiple queries", func() {
 			collectedMetrics, err := collector.Collect()
 			Expect(err).NotTo(HaveOccurred())
-			expectedTags := map[string]string{"source": "sql"}
+			expectedTags1 := map[string]string{"source": "sql", "tag1": "val1", "tag2": "val2"}
+			expectedTags2 := map[string]string{"source": "sql"}
 			Expect(collectedMetrics).To(ConsistOf(
-				metrics.Metric{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
-				metrics.Metric{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},
-				metrics.Metric{Key: "baz", Value: 3, Unit: "conn", Tags: expectedTags},
-				metrics.Metric{Key: "foo2", Value: 1, Unit: "gauge", Tags: expectedTags},
+				metrics.Metric{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags1},
+				metrics.Metric{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags1},
+				metrics.Metric{Key: "baz", Value: 3, Unit: "conn", Tags: expectedTags1},
+				metrics.Metric{Key: "foo2", Value: 1, Unit: "gauge", Tags: expectedTags2},
 			))
 		})
 
@@ -187,14 +198,14 @@ var _ = Describe("helpers", func() {
 		dbConn.Close()
 	})
 
-	Context("getRowDataAsMap()", func() {
+	Context("getRowDataAsMaps()", func() {
 		It("should error when unexpected type from database", func() {
 			rows, err := dbConn.Query("SELECT 'Hello World'")
 
 			Expect(err).NotTo(HaveOccurred())
 
 			for rows.Next() {
-				_, err = getRowDataAsMap(rows)
+				_, _, err = getRowDataAsMaps(1, rows)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(MatchRegexp("converting driver.Value type .+")))
 			}
@@ -206,24 +217,91 @@ var _ = Describe("helpers", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for rows.Next() {
-				rows.Close()
-				_, err = getRowDataAsMap(rows)
+				rows.Close() // Close the rows
+				_, _, err = getRowDataAsMaps(1, rows)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(MatchRegexp("Rows are closed")))
 			}
 		})
 
-		It("should succeed when returning a values", func() {
-			rows, err := dbConn.Query("SELECT 1::integer as foo, '2'::varchar as bar, 3::double precision as baz")
+		It("should succeed when returning values", func() {
+			rows, err := dbConn.Query(`
+				SELECT
+					1::integer as foo,
+					'2'::varchar as bar,
+					3::double precision as baz
+			`)
 
 			Expect(err).NotTo(HaveOccurred())
 
 			for rows.Next() {
-				data, err := getRowDataAsMap(rows)
+				data, _, err := getRowDataAsMaps(3, rows)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(data).To(Equal(map[string]float64{"foo": 1.0, "bar": 2.0, "baz": 3.0}))
 			}
 		})
+
+		It("should returning only the number of values indicated", func() {
+			rows, err := dbConn.Query(`
+				SELECT
+					1::integer as foo,
+					'2'::varchar as bar,
+					3::double precision as baz
+			`)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			for rows.Next() {
+				data, _, err := getRowDataAsMaps(1, rows)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data).To(Equal(map[string]float64{"foo": 1.0}))
+			}
+		})
+
+		It("should fail if the query does not have enough values", func() {
+			rows, err := dbConn.Query("SELECT 1::integer as foo")
+
+			Expect(err).NotTo(HaveOccurred())
+
+			for rows.Next() {
+				_, _, err := getRowDataAsMaps(4, rows)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(MatchRegexp("Expected 4 values but the row only has 1 columns")))
+			}
+		})
+
+		It("should succeed when returning values and tags", func() {
+			rows, err := dbConn.Query(`
+				SELECT
+					1::integer as foo,
+					'2'::varchar as bar,
+					3::double precision as baz,
+					'val1' as tag1,
+					'val2' as tag2
+			`)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			for rows.Next() {
+				data, tags, err := getRowDataAsMaps(3, rows)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data).To(Equal(map[string]float64{"foo": 1.0, "bar": 2.0, "baz": 3.0}))
+				Expect(tags).To(Equal(map[string]string{"tag1": "val1", "tag2": "val2"}))
+			}
+		})
+		It("should succeed tags is not a string", func() {
+			rows, err := dbConn.Query("SELECT 1::integer as foo, 1 as tag1")
+
+			Expect(err).NotTo(HaveOccurred())
+
+			for rows.Next() {
+				data, tags, err := getRowDataAsMaps(1, rows)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data).To(Equal(map[string]float64{"foo": 1.0}))
+				Expect(tags).To(Equal(map[string]string{"tag1": "1"}))
+			}
+		})
+
 	})
 
 	Context("queryToMetrics()", func() {
@@ -253,7 +331,7 @@ var _ = Describe("helpers", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(rowMetrics)).To(Equal(3))
-			expectedTags := map[string]string{"source": "sql"}
+			expectedTags := map[string]string{"source": "sql", "tag1": "val1", "tag2": "val2"}
 			Expect(rowMetrics).To(Equal([]metrics.Metric{
 				{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
 				{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},

--- a/pkg/emitter/loggregator.go
+++ b/pkg/emitter/loggregator.go
@@ -81,5 +81,6 @@ func (e *LoggregatorEmitter) Emit(me metrics.MetricEnvelope) {
 		loggregator.WithGaugeValue(me.Metric.Key, me.Metric.Value, me.Metric.Unit),
 		loggregator.WithGaugeSourceInfo(me.InstanceGUID, "0"),
 		WithTimestamp(timestamp),
+		loggregator.WithEnvelopeTags(me.Metric.Tags),
 	)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,6 +6,7 @@ type Metric struct {
 	Timestamp int64
 	Value     float64
 	Unit      string
+	Tags      map[string]string
 }
 
 // MetricEnvelope ...

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math/rand"
 	"time"
 )
 
@@ -37,4 +38,14 @@ func WithTimeout(timeout time.Duration, payload func()) bool {
 		timeoutHappened = true
 	}
 	return true
+}
+
+func RandomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz")
+	rand.Seed(time.Now().UnixNano())
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -48,4 +48,14 @@ var _ = Describe("utils", func() {
 			Expect(ret).To(BeTrue())
 		})
 	})
+
+	Context("RandomString", func() {
+		It("Returns random strings", func() {
+			str1 := RandomString(10)
+			str2 := RandomString(10)
+			Expect(str1).ToNot(BeEmpty())
+			Expect(str2).ToNot(BeEmpty())
+			Expect(str1).ToNot(Equal(str2))
+		})
+	})
 })


### PR DESCRIPTION
What?
-----

We want to add multiple metrics to the collector.
We will add metrics from cloudwatch [1] and SQL postgres ones.

[1] https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/rds-metricscollected.html

In this PR we added multiple metrics we found useful. We were not sure about
some of the cloudwatch ones.

We additionally added the capability of tagging the metrics, which would allow us to tag metrics with dynamic names like `table_name`

We did not implement metrics for query latency or slow queries, as that seems
more complicated: We need to enable slow query logging in postgres parameter
groups and read the logs using the AWS API.

We unit tested the new metrics for postgres. We did not see the point of
testing the new cloudwatch ones, but they can be tested manually.

How to review?
-------------

 1. Code review
 2. Check if the metrics make sense
 3. Check if the naming of metrics and tags makes sense.

The SQL based metrics can be tested in a docker container locally.

The cloudwatch can be tested by running this locally as:

 1. edit `example-config.json` to point to a existing CF deployment with RDS instances.
 2. load your AWS creds.
 3. run `go run main.go -stdoutEmitter -config example_config.json`

Who?
----

Anyone but me