### PR TITLE
[#158594217] Disable per-table and index metrics

### DIFF
--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -55,24 +55,6 @@ var postgresMetricQueries = []MetricQuery{
 	MetricQuery{
 		Query: `
 			SELECT
-				pg_table_size(C.oid) as table_size,
-				relname as table_name,
-				current_database() as dbname
-			FROM pg_class C LEFT JOIN pg_namespace N
-			ON (N.oid = C.relnamespace)
-			WHERE nspname NOT IN ('pg_catalog', 'information_schema')
-			AND nspname !~ '^pg_toast' AND relkind IN ('r')
-		`,
-		Metrics: []MetricQueryMeta{
-			{
-				Key:  "table_size",
-				Unit: "byte",
-			},
-		},
-	},
-	MetricQuery{
-		Query: `
-			SELECT
 				deadlocks as deadlocks,
 				xact_commit as commits,
 				xact_rollback as rollbacks,
@@ -123,8 +105,8 @@ var postgresMetricQueries = []MetricQuery{
 	MetricQuery{
 		Query: `
 			SELECT
-				COALESCE(seq_scan, 0) as seq_scan,
-				relname as table_name,
+				COALESCE(SUM(seq_scan), 0) as seq_scan,
+				COALESCE(SUM(idx_scan), 0) as idx_scan,
 				current_database() as dbname
 			FROM pg_stat_user_tables
 		`,
@@ -133,18 +115,6 @@ var postgresMetricQueries = []MetricQuery{
 				Key:  "seq_scan",
 				Unit: "scan",
 			},
-		},
-	},
-	MetricQuery{
-		Query: `
-			SELECT
-				idx_scan,
-				relname as table_name,
-				indexrelname as index_name,
-				current_database() as dbname
-			FROM pg_stat_user_indexes
-		`,
-		Metrics: []MetricQueryMeta{
 			{
 				Key:  "idx_scan",
 				Unit: "scan",

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -177,15 +177,6 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
 	})
 
-	It("can collect the table sizes", func() {
-		metric := getMetricByKey(collectedMetrics, "table_size")
-		Expect(metric).ToNot(BeNil())
-		Expect(metric.Value).To(BeNumerically(">=", 1))
-		Expect(metric.Unit).To(Equal("byte"))
-		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
-		Expect(metric.Tags).To(HaveKeyWithValue("table_name", "films"))
-	})
-
 	Context("pg_stat_database and pg_locks", func() {
 		It("can collect the database locks and deadlocks", func() {
 			metric := getMetricByKey(collectedMetrics, "deadlocks")
@@ -321,7 +312,6 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric.Value).To(BeNumerically("==", 0))
 		Expect(metric.Unit).To(Equal("scan"))
 		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
-		Expect(metric.Tags).To(HaveKeyWithValue("table_name", "films"))
 
 		initialSeqScanValue := metric.Value
 
@@ -330,8 +320,6 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric.Value).To(BeNumerically("==", 0))
 		Expect(metric.Unit).To(Equal("scan"))
 		Expect(metric.Tags).To(HaveKeyWithValue("dbname", testDBName))
-		Expect(metric.Tags).To(HaveKeyWithValue("table_name", "films"))
-		Expect(metric.Tags).To(HaveKeyWithValue("index_name", "title_idx"))
 
 		initialIdxScanValue := metric.Value
 


### PR DESCRIPTION
What?
------

To have per-table metrics is a nice to have, but not something
the user have requested. Also, we might have a explosion of metrics
when dealing with databases with lots of tables and indexes,
and this load is not easily predictable.

We have decided to disable this feature for the time being. The
tenants can query these metrics by themselves if they need to.

In this case, we:
 - remove per-table size
 - aggregate sequencial and index scan info

How to review
-------------

 - Code review

Dependencies
------------

Once merged, ask @keymon to generate a new bosh-release version and
do a PR in paas-cf.

Who?
----

Not me