### PR TITLE
[#158946642] Collect Mysql Metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: true
 
 language: go
 
@@ -11,17 +11,25 @@ services:
 
 addons:
   postgresql: "9.5"
+  apt:
+    sources:
+      - mysql-5.7-trusty
+    packages:
+      - mysql-server
+      - mysql-client
 
 env:
   global:
   - PGVERSION=9.5
-
 
 install:
   - go get -t ./...
   - go get github.com/onsi/ginkgo/ginkgo
 
 before_script:
+  - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
+  - sudo mysql_upgrade
+  - sudo service mysql restart
   - psql -c 'create database mydb;' -U postgres
 
 script:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,8 @@
 [[projects]]
   name = "code.cloudfoundry.org/lager"
   packages = ["."]
-  revision = "de8e9c6c6e474e5e3668aea1a9817bdb4ceeceb0"
+  revision = "b60e04e119450552243196105bae0d42179ee0ca"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/alphagov/paas-rds-broker"
@@ -32,8 +33,8 @@
     "sqlengine",
     "utils"
   ]
-  revision = "a662af4b57958b02e6988606132dc30452363ec8"
-  version = "v0.18.0"
+  revision = "d59802630127d0c2a957f555dc8c4677536a00ff"
+  version = "v0.19.0"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: test unit integration start_postgres_docker stop_postgres_docker
+.PHONY: test unit integration start_docker_dbs stop_docker_dbs
 
-TEST_DATABASE_URL ?= postgres://postgres:@localhost:5432/?sslmode=disable
+TEST_POSTGRES_URL ?= postgres://postgres:@localhost:5432/?sslmode=disable
+TETS_MYSQL_URL ?= root:@tcp(localhost:3306)/mysql?tls=false
 
 test: unit
 
@@ -10,9 +11,15 @@ unit:
 integration:
 	ginkgo -v -r ci/blackbox
 
-start_postgres_docker:
+start_docker_dbs:
 	docker run --rm -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
+	docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
+	until docker exec mysql mysqladmin ping --silent; do \
+		printf "."; sleep 1;                             \
+	done
 
-stop_postgres_docker:
+stop_docker_dbs:
 	docker stop postgres
 	docker rm postgres
+	docker stop mysql
+	docker rm mysql

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ integration:
 
 start_docker_dbs:
 	docker run --rm -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
-	docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
+	docker run --rm -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
 	until docker exec mysql mysqladmin ping --silent; do \
 		printf "."; sleep 1;                             \
 	done

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,4 @@ start_docker_dbs:
 
 stop_docker_dbs:
 	docker stop postgres
-	docker rm postgres
 	docker stop mysql
-	docker rm mysql

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ make start_docker_dbs
 Or manually by:
 
 ```
-docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
-docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
+docker run --rm -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
+docker run --rm -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
 ```
 
 You can tear it down after with:
 
 ```
-make stop_docker_db
+make stop_docker_dbs
 
 ```
 Or manually by:
 
 ```
-docker rm -f postgres
-docker rm -f mysql
+docker stop postgres
+docker stop mysql
 ```
 
 installing the dependencies can be achieved by running:

--- a/README.md
+++ b/README.md
@@ -6,31 +6,33 @@ PaaS and gathering metrics. Pushing them to loggregator.
 
 ## Testing
 
-In order to run the tests, you will be required to run postgres instance on
+In order to run the tests, you will be required to run the DB instances on
 your machine.
 
 We usually use `docker` to achieve that, either by using the make target:
 
 ```
-make start_postgres_docker
+make start_docker_dbs
 ```
 
 Or manually by:
 
 ```
 docker run -p 5432:5432 --name postgres -e POSTGRES_PASSWORD= -d postgres:9.5
+docker run -p 3306:3306 --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:5.7
 ```
 
 You can tear it down after with:
 
 ```
-make stop_postgres_docker
+make stop_docker_db
 
 ```
 Or manually by:
 
 ```
 docker rm -f postgres
+docker rm -f mysql
 ```
 
 installing the dependencies can be achieved by running:
@@ -63,6 +65,6 @@ We provide a `Makefile` for the different tasks to run and test the application.
 
 ## How does it work?
 
-The metrics collector queries AWS RDS for Postgres instances. Once these have been found the metrics collector generated the master password for each instance in order to spawn a worker process that connects to the instance. There is one process per instance. This runs a series of queries against the instance and pushes the results to loggregator. 
+The metrics collector queries AWS RDS for instances. Once these have been found the metrics collector generated the master password for each instance in order to spawn a worker process that connects to the instance. There is one process per instance. This runs a series of queries against the instance and pushes the results to loggregator.
 
 From Loggregator the metics can be collected by our tenants in the same manner as any other metrics. This is now through the plugin for log-cache.

--- a/ci/blackbox/helpers_test.go
+++ b/ci/blackbox/helpers_test.go
@@ -25,15 +25,16 @@ func startNewBroker(rdsBrokerConfig *rdsconfig.Config) (*gexec.Session, *BrokerA
 	Expect(err).ToNot(HaveOccurred())
 	defer os.Remove(configFile.Name())
 
+	// start the broker in a random port
+	rdsBrokerPort := freeport.GetPort()
+	rdsBrokerConfig.Port = rdsBrokerPort
+
 	configJSON, err := json.Marshal(rdsBrokerConfig)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(ioutil.WriteFile(configFile.Name(), configJSON, 0644)).To(Succeed())
 	Expect(configFile.Close()).To(Succeed())
 
-	// start the broker in a random port
-	rdsBrokerPort := freeport.GetPort()
 	command := exec.Command(rdsBrokerPath,
-		fmt.Sprintf("-port=%d", rdsBrokerPort),
 		fmt.Sprintf("-config=%s", configFile.Name()),
 	)
 	rdsBrokerSession, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -41,8 +42,7 @@ func startNewBroker(rdsBrokerConfig *rdsconfig.Config) (*gexec.Session, *BrokerA
 
 	// Wait for it to be listening
 	Eventually(rdsBrokerSession, 10*time.Second).Should(And(
-		gbytes.Say("rds-broker.start"),
-		gbytes.Say(fmt.Sprintf(`{"port":"%d"}`, rdsBrokerPort)),
+		gbytes.Say(fmt.Sprintf(`{"port":%d}`, rdsBrokerPort)),
 	))
 
 	Consistently(rdsBrokerSession, 3*time.Second).ShouldNot(gexec.Exit())

--- a/ci/blackbox/rds_metric_collector_test.go
+++ b/ci/blackbox/rds_metric_collector_test.go
@@ -34,9 +34,11 @@ var _ = Describe("RDS Metrics Collector", func() {
 				provisionInstance(instanceID, serviceID, planID)
 
 				By("checking that collector discovers the instance and emits metrics")
-				Eventually(rdsMetricsCollectorSession, 30*time.Second).Should(gbytes.Say("scheduler.start_worker"))
-				Eventually(rdsMetricsCollectorSession, 30*time.Second).Should(gbytes.Say("loggregator_emitter.emit"))
-				Eventually(rdsMetricsCollectorSession, 240*time.Second).Should(gbytes.Say("cloudwatch_metrics_collector.retrieved_metric"))
+				Eventually(rdsMetricsCollectorSession, 60*time.Second).Should(
+					gbytes.Say(
+						fmt.Sprintf(`scheduler.started_worker.*"driver":"%s"`, serviceID),
+					),
+				)
 
 				By("receiving several seconds of metrics in the fake loggregator server")
 

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -14,10 +14,16 @@ run:
     - -e
     - -c
     - |
-      apk add -U git make
+      apk add -U git make curl ca-certificates
       go get github.com/onsi/ginkgo/ginkgo
 
+
+      # pull the RDS broker code
       go get github.com/alphagov/paas-rds-broker
+
+      # install the AWS RDS CA certs
+      curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem > /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem
+      update-ca-certificates
 
       cp -Ra repo "${GOPATH}/src/github.com/alphagov/paas-rds-metric-collector"
       cd "${GOPATH}/src/github.com/alphagov/paas-rds-metric-collector"

--- a/fixtures/broker_config.json
+++ b/fixtures/broker_config.json
@@ -1,5 +1,5 @@
 {
-  "log_level": "DEBUG",
+  "log_level": "INFO",
   "password": "password",
   "cron_schedule": "0 0 * * *",
   "keep_snapshots_for_days": 35,

--- a/fixtures/broker_config.json
+++ b/fixtures/broker_config.json
@@ -17,30 +17,10 @@
           "plan_updateable": true,
           "plans": [
             {
-              "description": "Micro plan",
-              "free": false,
-              "id": "micro",
-              "name": "micro",
-              "rds_properties": {
-                "allocated_storage": 10,
-                "db_instance_class": "db.t2.micro",
-                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
-                "engine": "postgres",
-                "engine_version": "9.5",
-                "vpc_security_group_ids": [
-                  "POPULATED_BY_TEST_SUITE"
-                ],
-                "postgres_extensions": [
-                  "uuid-ossp",
-                  "postgis"
-                ]
-              }
-            },
-            {
               "description": "Micro plan without final snapshot",
               "free": false,
-              "id": "micro-without-snapshot",
-              "name": "micro-without-snapshot",
+              "id": "postgres-micro-without-snapshot",
+              "name": "postgres-micro-without-snapshot",
               "rds_properties": {
                 "allocated_storage": 10,
                 "db_instance_class": "db.t2.micro",
@@ -54,6 +34,31 @@
                 "postgres_extensions": [
                   "uuid-ossp",
                   "postgis"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "description": "AWS RDS MySQL service",
+          "id": "mysql",
+          "name": "mysql",
+          "plan_updateable": true,
+          "plans": [
+            {
+              "description": "Micro plan without final snapshot",
+              "free": false,
+              "id": "mysql-micro-without-snapshot",
+              "name": "mysql-micro-without-snapshot",
+              "rds_properties": {
+                "allocated_storage": 10,
+                "db_instance_class": "db.t2.micro",
+                "db_subnet_group_name": "POPULATED_BY_TEST_SUITE",
+                "engine": "mysql",
+                "engine_version": "5.7",
+                "skip_final_snapshot": true,
+                "vpc_security_group_ids": [
+                  "POPULATED_BY_TEST_SUITE"
                 ]
               }
             }

--- a/fixtures/collector_config.json
+++ b/fixtures/collector_config.json
@@ -1,5 +1,5 @@
 {
-	"log_level": "DEBUG",
+	"log_level": "INFO",
 	"aws": {
 		"region": "eu-west-1"
 	},

--- a/main.go
+++ b/main.go
@@ -114,6 +114,11 @@ func main() {
 		logger.Session("postgres_metrics_collector"),
 	)
 
+	mysqlMetricsCollectorDriver := collector.NewMysqlMetricsCollectorDriver(
+		rdsBrokerInfo,
+		logger.Session("mysql_metrics_collector"),
+	)
+
 	cloudWatchMetricsCollectorDriver := collector.NewCloudWatchCollectorDriver(
 		awsSession,
 		rdsBrokerInfo,
@@ -127,6 +132,7 @@ func main() {
 		logger.Session("scheduler"),
 	)
 	scheduler.WithDriver(postgresMetricsCollectorDriver)
+	scheduler.WithDriver(mysqlMetricsCollectorDriver)
 	scheduler.WithDriver(cloudWatchMetricsCollectorDriver)
 
 	err = scheduler.Start()

--- a/pkg/brokerinfo/brokerinfo.go
+++ b/pkg/brokerinfo/brokerinfo.go
@@ -2,6 +2,7 @@ package brokerinfo
 
 type InstanceInfo struct {
 	GUID string
+	Type string
 }
 
 // BrokerInfo ...

--- a/pkg/brokerinfo/brokerinfo.go
+++ b/pkg/brokerinfo/brokerinfo.go
@@ -1,8 +1,12 @@
 package brokerinfo
 
+type InstanceInfo struct {
+	GUID string
+}
+
 // BrokerInfo ...
 type BrokerInfo interface {
-	ListInstanceGUIDs() ([]string, error)
-	ConnectionString(instanceGUID string) (string, error)
-	GetInstanceName(instanceGUID string) string
+	ListInstances() ([]InstanceInfo, error)
+	ConnectionString(instanceInfo InstanceInfo) (string, error)
+	GetInstanceName(instanceInfo InstanceInfo) string
 }

--- a/pkg/brokerinfo/fakebrokerinfo/fakebrokerinfo.go
+++ b/pkg/brokerinfo/fakebrokerinfo/fakebrokerinfo.go
@@ -1,22 +1,25 @@
 package fakebrokerinfo
 
-import "github.com/stretchr/testify/mock"
+import (
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
+	"github.com/stretchr/testify/mock"
+)
 
 type FakeBrokerInfo struct {
 	mock.Mock
 }
 
-func (b *FakeBrokerInfo) ConnectionString(instanceGUID string) (string, error) {
-	args := b.Called(instanceGUID)
+func (b *FakeBrokerInfo) ConnectionString(instanceInfo brokerinfo.InstanceInfo) (string, error) {
+	args := b.Called(instanceInfo)
 	return args.String(0), args.Error(1)
 }
 
-func (b *FakeBrokerInfo) ListInstanceGUIDs() ([]string, error) {
+func (b *FakeBrokerInfo) ListInstances() ([]brokerinfo.InstanceInfo, error) {
 	args := b.Called()
-	return args.Get(0).([]string), args.Error(1)
+	return args.Get(0).([]brokerinfo.InstanceInfo), args.Error(1)
 }
 
-func (b *FakeBrokerInfo) GetInstanceName(instanceGUID string) string {
-	args := b.Called()
+func (b *FakeBrokerInfo) GetInstanceName(instanceInfo brokerinfo.InstanceInfo) string {
+	args := b.Called(instanceInfo)
 	return args.String(0)
 }

--- a/pkg/brokerinfo/rdsbrokerinfo.go
+++ b/pkg/brokerinfo/rdsbrokerinfo.go
@@ -33,35 +33,37 @@ func NewRDSBrokerInfo(
 	}
 }
 
-func (r *RDSBrokerInfo) ListInstanceGUIDs() ([]string, error) {
-	serviceInstanceGUIDs := []string{}
+func (r *RDSBrokerInfo) ListInstances() ([]InstanceInfo, error) {
+	serviceInstances := []InstanceInfo{}
 
 	dbInstanceDetailsList, err := r.dbInstance.DescribeByTag("Broker Name", r.brokerName)
 	if err != nil {
 		r.logger.Error("retriving list of AWS instances", err, lager.Data{"brokerName": r.brokerName})
-		return serviceInstanceGUIDs, err
+		return serviceInstances, err
 	}
 
 	for _, dbDetails := range dbInstanceDetailsList {
 		if dbDetails.Engine == "postgres" {
-			serviceInstanceGUID := r.dbInstanceIdentifierToServiceInstanceID(dbDetails.Identifier)
-			serviceInstanceGUIDs = append(serviceInstanceGUIDs, serviceInstanceGUID)
+			instanceInfo := InstanceInfo{
+				GUID: r.dbInstanceIdentifierToServiceInstanceID(dbDetails.Identifier),
+			}
+			serviceInstances = append(serviceInstances, instanceInfo)
 		}
 	}
-	return serviceInstanceGUIDs, nil
+	return serviceInstances, nil
 }
 
-func (r *RDSBrokerInfo) ConnectionString(instanceGUID string) (string, error) {
-	dbInstanceDetails, err := r.dbInstance.Describe(r.dbInstanceIdentifier(instanceGUID))
+func (r *RDSBrokerInfo) ConnectionString(instanceInfo InstanceInfo) (string, error) {
+	dbInstanceDetails, err := r.dbInstance.Describe(r.dbInstanceIdentifier(instanceInfo.GUID))
 	if err != nil {
-		r.logger.Error("obtaining instances details", err, lager.Data{"brokerName": r.brokerName, "instanceGUID": instanceGUID})
+		r.logger.Error("obtaining instances details", err, lager.Data{"brokerName": r.brokerName, "instanceInfo": instanceInfo})
 		return "", err
 	}
 
 	dbAddress := dbInstanceDetails.Address
 	dbPort := dbInstanceDetails.Port
 	masterUsername := dbInstanceDetails.MasterUsername
-	masterPassword := r.generateMasterPassword(instanceGUID)
+	masterPassword := r.generateMasterPassword(instanceInfo.GUID)
 	dbName := dbInstanceDetails.DBName
 
 	ConnectionString := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=require", masterUsername, masterPassword, dbAddress, dbPort, dbName)
@@ -70,8 +72,8 @@ func (r *RDSBrokerInfo) ConnectionString(instanceGUID string) (string, error) {
 
 }
 
-func (r *RDSBrokerInfo) GetInstanceName(instanceGUID string) string {
-	return r.dbInstanceIdentifier(instanceGUID)
+func (r *RDSBrokerInfo) GetInstanceName(instanceInfo InstanceInfo) string {
+	return r.dbInstanceIdentifier(instanceInfo.GUID)
 }
 
 // FIXME: Following code has been copied from

--- a/pkg/brokerinfo/rdsbrokerinfo.go
+++ b/pkg/brokerinfo/rdsbrokerinfo.go
@@ -43,13 +43,14 @@ func (r *RDSBrokerInfo) ListInstances() ([]InstanceInfo, error) {
 	}
 
 	for _, dbDetails := range dbInstanceDetailsList {
-		if dbDetails.Engine == "postgres" {
-			instanceInfo := InstanceInfo{
-				GUID: r.dbInstanceIdentifierToServiceInstanceID(dbDetails.Identifier),
-				Type: "postgres",
-			}
-			serviceInstances = append(serviceInstances, instanceInfo)
+		if dbDetails.Engine != "postgres" && dbDetails.Engine != "mysql" {
+			continue
 		}
+		instanceInfo := InstanceInfo{
+			GUID: r.dbInstanceIdentifierToServiceInstanceID(dbDetails.Identifier),
+			Type: dbDetails.Engine,
+		}
+		serviceInstances = append(serviceInstances, instanceInfo)
 	}
 	return serviceInstances, nil
 }

--- a/pkg/brokerinfo/rdsbrokerinfo.go
+++ b/pkg/brokerinfo/rdsbrokerinfo.go
@@ -46,6 +46,7 @@ func (r *RDSBrokerInfo) ListInstances() ([]InstanceInfo, error) {
 		if dbDetails.Engine == "postgres" {
 			instanceInfo := InstanceInfo{
 				GUID: r.dbInstanceIdentifierToServiceInstanceID(dbDetails.Identifier),
+				Type: "postgres",
 			}
 			serviceInstances = append(serviceInstances, instanceInfo)
 		}
@@ -54,6 +55,9 @@ func (r *RDSBrokerInfo) ListInstances() ([]InstanceInfo, error) {
 }
 
 func (r *RDSBrokerInfo) ConnectionString(instanceInfo InstanceInfo) (string, error) {
+	if instanceInfo.Type != "postgres" {
+		return "", fmt.Errorf("invalid instance type: %s", instanceInfo.Type)
+	}
 	dbInstanceDetails, err := r.dbInstance.Describe(r.dbInstanceIdentifier(instanceInfo.GUID))
 	if err != nil {
 		r.logger.Error("obtaining instances details", err, lager.Data{"brokerName": r.brokerName, "instanceInfo": instanceInfo})

--- a/pkg/brokerinfo/rdsbrokerinfo.go
+++ b/pkg/brokerinfo/rdsbrokerinfo.go
@@ -77,7 +77,7 @@ func (r *RDSBrokerInfo) ConnectionString(instanceInfo InstanceInfo) (string, err
 	case "postgres":
 		ConnectionString = fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=require", masterUsername, masterPassword, dbAddress, dbPort, dbName)
 	case "mysql":
-		ConnectionString = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=true", masterUsername, masterPassword, dbAddress, dbPort, dbName)
+		ConnectionString = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=skip-verify", masterUsername, masterPassword, dbAddress, dbPort, dbName)
 	}
 
 	return ConnectionString, nil

--- a/pkg/brokerinfo/rdsbrokerinfo_test.go
+++ b/pkg/brokerinfo/rdsbrokerinfo_test.go
@@ -75,9 +75,9 @@ var _ = Describe("RDSBrokerInfo", func() {
 			Expect(fakeDBInstance.DescribeByTagValue).To(Equal("broker_name"))
 		})
 		It("returns the list of instances", func() {
-			instanceGUIDs, err := brokerInfo.ListInstances()
+			instances, err := brokerInfo.ListInstances()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(instanceGUIDs).To(ConsistOf(
+			Expect(instances).To(ConsistOf(
 				brokerinfo.InstanceInfo{GUID: "instance-id-1", Type: "postgres"},
 				brokerinfo.InstanceInfo{GUID: "instance-id-2", Type: "postgres"},
 				brokerinfo.InstanceInfo{GUID: "instance-id-3", Type: "mysql"},

--- a/pkg/brokerinfo/rdsbrokerinfo_test.go
+++ b/pkg/brokerinfo/rdsbrokerinfo_test.go
@@ -112,10 +112,17 @@ var _ = Describe("RDSBrokerInfo", func() {
 			Expect(fakeDBInstance.DescribeCalled).To(BeTrue())
 			Expect(fakeDBInstance.DescribeID).To(Equal("dbprefix-instance-id"))
 		})
-		It("returns the proper connection string", func() {
+		It("returns the proper connection string for postgres", func() {
+			fakeDBInstance.DescribeDBInstanceDetails.Engine = "postgres"
 			connectionString, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id", Type: "postgres"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(connectionString).To(Equal("postgresql://master-username:9Fs6CWnuwf0BAY3rDFAels3OXANSo0-M@endpoint-address.example.com:5432/dbprefix-db?sslmode=require"))
+		})
+		It("returns the proper connection string for mysql", func() {
+			fakeDBInstance.DescribeDBInstanceDetails.Engine = "mysql"
+			connectionString, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id", Type: "mysql"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(connectionString).To(Equal("master-username:9Fs6CWnuwf0BAY3rDFAels3OXANSo0-M@tcp(endpoint-address.example.com:5432)/dbprefix-db?tls=true"))
 		})
 		It("fails if the type is invalid", func() {
 			_, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id", Type: "foo"})

--- a/pkg/brokerinfo/rdsbrokerinfo_test.go
+++ b/pkg/brokerinfo/rdsbrokerinfo_test.go
@@ -80,6 +80,7 @@ var _ = Describe("RDSBrokerInfo", func() {
 			Expect(instanceGUIDs).To(ConsistOf(
 				brokerinfo.InstanceInfo{GUID: "instance-id-1", Type: "postgres"},
 				brokerinfo.InstanceInfo{GUID: "instance-id-2", Type: "postgres"},
+				brokerinfo.InstanceInfo{GUID: "instance-id-3", Type: "mysql"},
 			))
 		})
 	})

--- a/pkg/brokerinfo/rdsbrokerinfo_test.go
+++ b/pkg/brokerinfo/rdsbrokerinfo_test.go
@@ -32,7 +32,7 @@ var _ = Describe("RDSBrokerInfo", func() {
 		)
 	})
 
-	Context("ListInstanceGUIDs()", func() {
+	Context("ListInstances()", func() {
 		BeforeEach(func() {
 			fakeDBInstance.DescribeByTagDBInstanceDetails = []*awsrds.DBInstanceDetails{
 				&awsrds.DBInstanceDetails{
@@ -65,21 +65,21 @@ var _ = Describe("RDSBrokerInfo", func() {
 		It("returns error if it fails retrieving existing instances in AWS", func() {
 			fakeDBInstance.DescribeByTagError = fmt.Errorf("Error calling rds.DescribeByTag(...)")
 
-			_, err := brokerInfo.ListInstanceGUIDs()
+			_, err := brokerInfo.ListInstances()
 			Expect(err).To(HaveOccurred())
 		})
 		It("lists the instances for the right tag", func() {
-			_, err := brokerInfo.ListInstanceGUIDs()
+			_, err := brokerInfo.ListInstances()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeDBInstance.DescribeByTagKey).To(Equal("Broker Name"))
 			Expect(fakeDBInstance.DescribeByTagValue).To(Equal("broker_name"))
 		})
-		It("returns the list of instance GUIDs", func() {
-			instanceGUIDs, err := brokerInfo.ListInstanceGUIDs()
+		It("returns the list of instances", func() {
+			instanceGUIDs, err := brokerInfo.ListInstances()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(instanceGUIDs).To(ConsistOf(
-				"instance-id-1",
-				"instance-id-2",
+				brokerinfo.InstanceInfo{GUID: "instance-id-1"},
+				brokerinfo.InstanceInfo{GUID: "instance-id-2"},
 			))
 		})
 	})
@@ -98,17 +98,17 @@ var _ = Describe("RDSBrokerInfo", func() {
 		It("returns error if it fails retrieving existing instances in AWS", func() {
 			fakeDBInstance.DescribeError = fmt.Errorf("Error calling rds.Describe(...)")
 
-			_, err := brokerInfo.ConnectionString("instance-id")
+			_, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id"})
 			Expect(err).To(HaveOccurred())
 		})
 		It("retrieves information of the right AWS RDS instance", func() {
-			_, err := brokerInfo.ConnectionString("instance-id")
+			_, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeDBInstance.DescribeCalled).To(BeTrue())
 			Expect(fakeDBInstance.DescribeID).To(Equal("dbprefix-instance-id"))
 		})
 		It("returns the proper connection string", func() {
-			connectionString, err := brokerInfo.ConnectionString("instance-id")
+			connectionString, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(connectionString).To(Equal("postgresql://master-username:9Fs6CWnuwf0BAY3rDFAels3OXANSo0-M@endpoint-address.example.com:5432/dbprefix-db?sslmode=require"))
 		})

--- a/pkg/brokerinfo/rdsbrokerinfo_test.go
+++ b/pkg/brokerinfo/rdsbrokerinfo_test.go
@@ -122,7 +122,7 @@ var _ = Describe("RDSBrokerInfo", func() {
 			fakeDBInstance.DescribeDBInstanceDetails.Engine = "mysql"
 			connectionString, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id", Type: "mysql"})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(connectionString).To(Equal("master-username:9Fs6CWnuwf0BAY3rDFAels3OXANSo0-M@tcp(endpoint-address.example.com:5432)/dbprefix-db?tls=true"))
+			Expect(connectionString).To(Equal("master-username:9Fs6CWnuwf0BAY3rDFAels3OXANSo0-M@tcp(endpoint-address.example.com:5432)/dbprefix-db?tls=skip-verify"))
 		})
 		It("fails if the type is invalid", func() {
 			_, err := brokerInfo.ConnectionString(brokerinfo.InstanceInfo{GUID: "instance-id", Type: "foo"})

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -58,10 +58,10 @@ type CloudWatchCollectorDriver struct {
 }
 
 // NewCollector ...
-func (cw *CloudWatchCollectorDriver) NewCollector(instanceID string) (MetricsCollector, error) {
+func (cw *CloudWatchCollectorDriver) NewCollector(instanceInfo brokerinfo.InstanceInfo) (MetricsCollector, error) {
 	return &CloudWatchCollector{
 		client:   cloudwatch.New(cw.session),
-		instance: cw.brokerInfo.GetInstanceName(instanceID),
+		instance: cw.brokerInfo.GetInstanceName(instanceInfo),
 		logger:   cw.logger,
 	}, nil
 }

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -71,6 +71,10 @@ func (cw *CloudWatchCollectorDriver) GetName() string {
 	return "cloudwatch"
 }
 
+func (cw *CloudWatchCollectorDriver) SupportedTypes() []string {
+	return []string{"postgres"}
+}
+
 // CloudWatchCollector ...
 type CloudWatchCollector struct {
 	client   cloudwatchiface.CloudWatchAPI

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -72,7 +72,7 @@ func (cw *CloudWatchCollectorDriver) GetName() string {
 }
 
 func (cw *CloudWatchCollectorDriver) SupportedTypes() []string {
-	return []string{"postgres"}
+	return []string{"postgres", "mysql"}
 }
 
 // CloudWatchCollector ...

--- a/pkg/collector/cloudwatch_collector_test.go
+++ b/pkg/collector/cloudwatch_collector_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo/fakebrokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/collector/mocks"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -33,7 +34,7 @@ var _ = Describe("cloudwatch_collector", func() {
 
 		It("should create a NewCollector successfully", func() {
 
-			c, err := metricsCollectorDriver.NewCollector("__TEST_INSTANCE_ID__")
+			c, err := metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "__TEST_INSTANCE_ID__"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).NotTo(BeNil())
 		})

--- a/pkg/collector/collector_suite_test.go
+++ b/pkg/collector/collector_suite_test.go
@@ -12,16 +12,23 @@ import (
 )
 
 var postgresTestDatabaseConnectionURL string
+var mysqlTestDatabaseConnectionURL string
 var logger lager.Logger
 
 var _ = BeforeSuite(func() {
 	logger = lager.NewLogger("tests")
 	logger.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.INFO))
 
-	postgresTestDatabaseConnectionURL = os.Getenv("TEST_DATABASE_URL")
+	postgresTestDatabaseConnectionURL = os.Getenv("TEST_POSTGRES_URL")
 	if postgresTestDatabaseConnectionURL == "" {
 		postgresTestDatabaseConnectionURL = "postgresql://postgres@localhost:5432?sslmode=disable"
-		fmt.Fprintf(GinkgoWriter, "$TEST_DATABASE_URL not defined, using default: %s\n", postgresTestDatabaseConnectionURL)
+		fmt.Fprintf(GinkgoWriter, "$TEST_POSTGRES_URL not defined, using default: %s\n", postgresTestDatabaseConnectionURL)
+	}
+
+	mysqlTestDatabaseConnectionURL = os.Getenv("TEST_MYSQL_URL")
+	if mysqlTestDatabaseConnectionURL == "" {
+		mysqlTestDatabaseConnectionURL = "root:@tcp(localhost:3306)/mysql?tls=false"
+		fmt.Fprintf(GinkgoWriter, "$TEST_MYSQL_URL not defined, using default: %s\n", mysqlTestDatabaseConnectionURL)
 	}
 })
 

--- a/pkg/collector/helpers_test.go
+++ b/pkg/collector/helpers_test.go
@@ -1,0 +1,78 @@
+package collector
+
+import (
+	"database/sql"
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
+)
+
+func openMultipleDBConns(count int, driver, url string) func() {
+	var dbConns []*sql.DB
+	success := false
+
+	closeDBConns := func() {
+		for _, c := range dbConns {
+			c.Close()
+		}
+	}
+	defer func() {
+		if success != true {
+			closeDBConns()
+		}
+	}()
+
+	for i := 0; i < count; i++ {
+		dbConn, err := sql.Open(driver, url)
+		Expect(err).ToNot(HaveOccurred())
+		err = dbConn.Ping()
+		Expect(err).ToNot(HaveOccurred())
+		dbConns = append(dbConns, dbConn)
+	}
+	success = true
+	return closeDBConns
+}
+
+func getMetricByKey(collectedMetrics []metrics.Metric, key string) *metrics.Metric {
+	for _, metric := range collectedMetrics {
+		if metric.Key == key {
+			return &metric
+		}
+	}
+	return nil
+}
+
+// Replaces the DB name in a postgres DB connection string
+func injectDBName(connectionString, newDBName string) string {
+	re := regexp.MustCompile("(.*:[0-9()]+)[^?]*([?].*)?$")
+	return re.ReplaceAllString(connectionString, fmt.Sprintf("$1/%s$2", newDBName))
+}
+
+var _ = Describe("injectDBName", func() {
+	It("replaces the db name", func() {
+		Expect(
+			injectDBName("postgresql://postgres@localhost:5432/foo?sslmode=disable", "mydb"),
+		).To(Equal(
+			"postgresql://postgres@localhost:5432/mydb?sslmode=disable",
+		))
+		Expect(
+			injectDBName("postgresql://postgres@localhost:5432?sslmode=disable", "mydb"),
+		).To(Equal(
+			"postgresql://postgres@localhost:5432/mydb?sslmode=disable",
+		))
+		Expect(
+			injectDBName("user:pass@tcp(localhost:3306)?something=false", "mydb"),
+		).To(Equal(
+			"user:pass@tcp(localhost:3306)/mydb?something=false",
+		))
+		Expect(
+			injectDBName("user:pass@tcp(localhost:3306)/foo?something=false", "mydb"),
+		).To(Equal(
+			"user:pass@tcp(localhost:3306)/mydb?something=false",
+		))
+	})
+})

--- a/pkg/collector/metrics_collector.go
+++ b/pkg/collector/metrics_collector.go
@@ -1,10 +1,13 @@
 package collector
 
-import "github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
+import (
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
+)
 
 // MetricsCollectorDriver ...
 type MetricsCollectorDriver interface {
-	NewCollector(instanceID string) (MetricsCollector, error)
+	NewCollector(instanceInfo brokerinfo.InstanceInfo) (MetricsCollector, error)
 	GetName() string
 }
 

--- a/pkg/collector/metrics_collector.go
+++ b/pkg/collector/metrics_collector.go
@@ -9,6 +9,7 @@ import (
 type MetricsCollectorDriver interface {
 	NewCollector(instanceInfo brokerinfo.InstanceInfo) (MetricsCollector, error)
 	GetName() string
+	SupportedTypes() []string
 }
 
 // MetricsCollector ...

--- a/pkg/collector/mysql_collector.go
+++ b/pkg/collector/mysql_collector.go
@@ -14,11 +14,18 @@ var mysqlMetricQueries = []metricQuery{
 		Query: `
 			SELECT *
 			FROM performance_schema.global_status
-			WHERE variable_name = 'Threads_connected';
+			WHERE variable_name IN (
+				 'Threads_connected'
+				,'Threads_running'
+			);
 		`,
 		Metrics: []metricQueryMeta{
 			{
 				Key:  "threads_connected",
+				Unit: "conn",
+			},
+			{
+				Key:  "threads_running",
 				Unit: "conn",
 			},
 		},

--- a/pkg/collector/mysql_collector.go
+++ b/pkg/collector/mysql_collector.go
@@ -15,8 +15,14 @@ var mysqlMetricQueries = []metricQuery{
 			SELECT *
 			FROM performance_schema.global_status
 			WHERE variable_name IN (
-				 'Threads_connected'
-				,'Threads_running'
+			   'Threads_connected'
+			  ,'Threads_running'
+			  ,'Threads_created'
+			  ,'Connections'
+			  ,'Queries'
+			  ,'Questions'
+			  ,'Aborted_clients'
+			  ,'Aborted_connects'
 			);
 		`,
 		Metrics: []metricQueryMeta{
@@ -27,6 +33,159 @@ var mysqlMetricQueries = []metricQuery{
 			{
 				Key:  "threads_running",
 				Unit: "conn",
+			},
+			{
+				Key:  "threads_created",
+				Unit: "conn",
+			},
+			{
+				Key:  "queries",
+				Unit: "conn",
+			},
+			{
+				Key:  "questions",
+				Unit: "conn",
+			},
+			{
+				Key:  "aborted_clients",
+				Unit: "conn",
+			},
+			{
+				Key:  "aborted_connects",
+				Unit: "conn",
+			},
+		},
+	},
+	&rowMetricQuery{
+		Query: `
+			SELECT *
+			FROM performance_schema.global_status
+			WHERE variable_name IN (
+			   'Innodb_row_lock_waits'
+			  ,'Innodb_row_lock_time'
+			  ,'Innodb_num_open_files'
+			  ,'Innodb_log_waits'
+			  ,'Innodb_buffer_pool_bytes_data'
+			  ,'Innodb_buffer_pool_bytes_dirty'
+			  ,'Innodb_buffer_pool_pages_data'
+			  ,'Innodb_buffer_pool_pages_dirty'
+			  ,'Innodb_buffer_pool_pages_flushed'
+			  ,'Innodb_buffer_pool_pages_free'
+			  ,'Innodb_buffer_pool_pages_misc'
+			  ,'Innodb_buffer_pool_pages_total'
+			  ,'Innodb_buffer_pool_read_ahead'
+			  ,'Innodb_buffer_pool_read_ahead_evicted'
+			  ,'Innodb_buffer_pool_read_ahead_rnd'
+			  ,'Innodb_buffer_pool_read_requests'
+			  ,'Innodb_buffer_pool_reads'
+			  ,'Innodb_buffer_pool_wait_free'
+			  ,'Innodb_buffer_pool_write_requests'
+			);
+		`,
+		Metrics: []metricQueryMeta{
+			{
+				Key:  "innodb_row_lock_waits",
+				Unit: "guage",
+			},
+			{
+				Key:  "innodb_row_lock_time",
+				Unit: "ms",
+			},
+			{
+				Key:  "innodb_num_open_files",
+				Unit: "files",
+			},
+			{
+				Key:  "innodb_log_waits",
+				Unit: "guage",
+			},
+			{
+				Key:  "innodb_buffer_pool_bytes_data",
+				Unit: "bytes",
+			},
+			{
+				Key:  "innodb_buffer_pool_bytes_dirty",
+				Unit: "bytes",
+			},
+			{
+				Key:  "innodb_buffer_pool_pages_data",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_pages_dirty",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_pages_flushed",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_pages_free",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_pages_misc",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_pages_total",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_read_ahead",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_read_ahead_evicted",
+				Unit: "pages",
+			},
+			{
+				Key:  "innodb_buffer_pool_read_ahead_rnd",
+				Unit: "guage",
+			},
+			{
+				Key:  "innodb_buffer_pool_read_requests",
+				Unit: "conn",
+			},
+			{
+				Key:  "innodb_buffer_pool_reads",
+				Unit: "guage",
+			},
+			{
+				Key:  "innodb_buffer_pool_wait_free",
+				Unit: "guage",
+			},
+			{
+				Key:  "innodb_buffer_pool_write_requests",
+				Unit: "guage",
+			},
+		},
+	},
+	&columnMetricQuery{
+		Query: `
+			SELECT
+					variable_value as max_connections
+			FROM performance_schema.global_variables
+			WHERE variable_name = 'max_connections';
+		`,
+		Metrics: []metricQueryMeta{
+			{
+				Key:  "max_connections",
+				Unit: "conn",
+			},
+		},
+	},
+	&columnMetricQuery{
+		Query: `
+			SELECT
+					SUM(variable_value) as connection_errors
+			FROM performance_schema.global_status
+			WHERE variable_name like 'Connection_errors_%';
+		`,
+		Metrics: []metricQueryMeta{
+			{
+				Key:  "connection_errors",
+				Unit: "err",
 			},
 		},
 	},

--- a/pkg/collector/mysql_collector.go
+++ b/pkg/collector/mysql_collector.go
@@ -1,0 +1,37 @@
+package collector
+
+import (
+	"code.cloudfoundry.org/lager"
+
+	// Used in the SQL driver.
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
+)
+
+var mysqlMetricQueries = []metricQuery{
+	&rowMetricQuery{
+		Query: `
+			SELECT *
+			FROM performance_schema.global_status
+			WHERE variable_name = 'Threads_connected';
+		`,
+		Metrics: []metricQueryMeta{
+			{
+				Key:  "threads_connected",
+				Unit: "conn",
+			},
+		},
+	},
+}
+
+// NewMysqlMetricsCollectorDriver ...
+func NewMysqlMetricsCollectorDriver(brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) MetricsCollectorDriver {
+	return &sqlMetricsCollectorDriver{
+		logger:     logger,
+		queries:    mysqlMetricQueries,
+		driver:     "mysql",
+		brokerInfo: brokerInfo,
+		name:       "mysql",
+	}
+}

--- a/pkg/collector/mysql_collector_test.go
+++ b/pkg/collector/mysql_collector_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -92,8 +93,9 @@ var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
 		initialConnections := metric.Value
 
 		By("Creating multiple new threads_connected")
-		closeDBConns := openMultipleDBConns(20, "mysql", mysqlTestDatabaseConnectionURL)
-		defer closeDBConns()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		openMultipleDBConns(ctx, 20, "mysql", mysqlTestDatabaseConnectionURL)
 
 		Eventually(func() float64 {
 			collectedMetrics, err = metricsCollector.Collect()
@@ -107,7 +109,7 @@ var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
 		)
 
 		By("Closing again the threads_connected")
-		closeDBConns()
+		cancel()
 
 		Eventually(func() float64 {
 			collectedMetrics, err = metricsCollector.Collect()

--- a/pkg/collector/mysql_collector_test.go
+++ b/pkg/collector/mysql_collector_test.go
@@ -81,6 +81,63 @@ var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
 		Expect(metricsCollectorDriver.GetName()).To(Equal("mysql"))
 	})
 
+	It("can collect the number of connection_errors", func() {
+		metric := getMetricByKey(collectedMetrics, "connection_errors")
+		Expect(metric).ToNot(BeNil())
+		Expect(metric.Value).To(BeNumerically(">=", 0))
+		Expect(metric.Unit).To(Equal("err"))
+	})
+
+	It("can collect connection-related metrics", func() {
+		metrics := []string{
+			"threads_running",
+			"threads_connected",
+			"threads_created",
+			"max_connections",
+			"queries",
+			"questions",
+			"aborted_connects",
+			"aborted_clients",
+		}
+		for _, v := range metrics {
+			By(fmt.Sprintf("Checking %s", v))
+			metric := getMetricByKey(collectedMetrics, v)
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+			Expect(metric.Unit).To(Equal("conn"))
+		}
+	})
+
+	It("can collect InnoDB metrics", func() {
+		metrics := []string{
+			"innodb_row_lock_time",
+			"innodb_row_lock_waits",
+			"innodb_num_open_files",
+			"innodb_log_waits",
+			"innodb_buffer_pool_bytes_data",
+			"innodb_buffer_pool_bytes_dirty",
+			"innodb_buffer_pool_pages_data",
+			"innodb_buffer_pool_pages_dirty",
+			"innodb_buffer_pool_pages_flushed",
+			"innodb_buffer_pool_pages_free",
+			"innodb_buffer_pool_pages_misc",
+			"innodb_buffer_pool_pages_total",
+			"innodb_buffer_pool_read_ahead",
+			"innodb_buffer_pool_read_ahead_evicted",
+			"innodb_buffer_pool_read_ahead_rnd",
+			"innodb_buffer_pool_read_requests",
+			"innodb_buffer_pool_reads",
+			"innodb_buffer_pool_wait_free",
+			"innodb_buffer_pool_write_requests",
+		}
+		for _, v := range metrics {
+			By(fmt.Sprintf("Checking %s", v))
+			metric := getMetricByKey(collectedMetrics, v)
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Value).To(BeNumerically(">=", 0))
+		}
+	})
+
 	It("can collect the number of threads connected and threads running", func() {
 		var err error
 

--- a/pkg/collector/mysql_collector_test.go
+++ b/pkg/collector/mysql_collector_test.go
@@ -33,16 +33,16 @@ var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
 		testDBName = utils.RandomString(10)
 		testDBConnectionString = injectDBName(mysqlTestDatabaseConnectionURL, testDBName)
 		mainDBConn, err := sql.Open("mysql", mysqlTestDatabaseConnectionURL)
-		defer mainDBConn.Close()
 		Expect(err).NotTo(HaveOccurred())
+		defer mainDBConn.Close()
 		_, err = mainDBConn.Exec(fmt.Sprintf("CREATE DATABASE %s", testDBName))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		dbConn, err := sql.Open("mysql", mysqlTestDatabaseConnectionURL)
-		defer dbConn.Close()
 		Expect(err).NotTo(HaveOccurred())
+		defer dbConn.Close()
 
 		_, err = dbConn.Query(fmt.Sprintf("DROP DATABASE %s", testDBName))
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/collector/mysql_collector_test.go
+++ b/pkg/collector/mysql_collector_test.go
@@ -1,0 +1,123 @@
+package collector
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo/fakebrokerinfo"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/utils"
+)
+
+var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
+
+	var (
+		brokerInfo             *fakebrokerinfo.FakeBrokerInfo
+		metricsCollectorDriver MetricsCollectorDriver
+		metricsCollector       MetricsCollector
+		collectedMetrics       []metrics.Metric
+		testDBName             string
+		testDBConnectionString string
+	)
+
+	BeforeEach(func() {
+		testDBName = utils.RandomString(10)
+		testDBConnectionString = injectDBName(mysqlTestDatabaseConnectionURL, testDBName)
+		mainDBConn, err := sql.Open("mysql", mysqlTestDatabaseConnectionURL)
+		defer mainDBConn.Close()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = mainDBConn.Exec(fmt.Sprintf("CREATE DATABASE %s", testDBName))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		dbConn, err := sql.Open("mysql", mysqlTestDatabaseConnectionURL)
+		defer dbConn.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = dbConn.Query(fmt.Sprintf("DROP DATABASE %s", testDBName))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+		var err error
+		brokerInfo = &fakebrokerinfo.FakeBrokerInfo{}
+		metricsCollectorDriver = NewMysqlMetricsCollectorDriver(brokerInfo, logger)
+
+		brokerInfo.On(
+			"ConnectionString", mock.Anything,
+		).Return(
+			testDBConnectionString, nil,
+		)
+		By("Creating a new collector")
+		metricsCollector, err = metricsCollectorDriver.NewCollector(
+			brokerinfo.InstanceInfo{
+				GUID: "instance-guid1",
+				Type: "mysql",
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Retrieving initial metrics")
+		collectedMetrics, err = metricsCollector.Collect()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := metricsCollector.Close()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns the right metricsCollectorDriver name", func() {
+		Expect(metricsCollectorDriver.GetName()).To(Equal("mysql"))
+	})
+
+	It("can collect the number of threads connected", func() {
+		var err error
+
+		By("Checking initial number of threads connected")
+		metric := getMetricByKey(collectedMetrics, "threads_connected")
+		Expect(metric).ToNot(BeNil())
+		Expect(metric.Value).To(BeNumerically(">=", 1))
+		Expect(metric.Unit).To(Equal("conn"))
+
+		initialConnections := metric.Value
+
+		By("Creating multiple new threads_connected")
+		closeDBConns := openMultipleDBConns(20, "mysql", mysqlTestDatabaseConnectionURL)
+		defer closeDBConns()
+
+		Eventually(func() float64 {
+			collectedMetrics, err = metricsCollector.Collect()
+			Expect(err).NotTo(HaveOccurred())
+			metric = getMetricByKey(collectedMetrics, "threads_connected")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Unit).To(Equal("conn"))
+			return metric.Value
+		}, 2*time.Second).Should(
+			BeNumerically(">=", 20),
+		)
+
+		By("Closing again the threads_connected")
+		closeDBConns()
+
+		Eventually(func() float64 {
+			collectedMetrics, err = metricsCollector.Collect()
+			Expect(err).NotTo(HaveOccurred())
+			metric = getMetricByKey(collectedMetrics, "threads_connected")
+			Expect(metric).ToNot(BeNil())
+			Expect(metric.Unit).To(Equal("conn"))
+			return metric.Value
+		}, 2*time.Second).Should(
+			BeNumerically("<=", initialConnections+5),
+		)
+	})
+})

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -9,35 +9,35 @@ import (
 	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
 )
 
-var postgresMetricQueries = []MetricQuery{
-	MetricQuery{
+var postgresMetricQueries = []metricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				SUM(numbackends) AS connections
 			FROM pg_stat_database
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "connections",
 				Unit: "conn",
 			},
 		},
 	},
-	MetricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 					setting::float as max_connections
 			FROM pg_settings
 			WHERE name = 'max_connections'
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "max_connections",
 				Unit: "conn",
 			},
 		},
 	},
-	MetricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				pg_database_size(pg_database.datname) as dbsize,
@@ -45,14 +45,14 @@ var postgresMetricQueries = []MetricQuery{
 			FROM pg_database
 			WHERE datname = current_database()
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "dbsize",
 				Unit: "byte",
 			},
 		},
 	},
-	MetricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				deadlocks as deadlocks,
@@ -67,7 +67,7 @@ var postgresMetricQueries = []MetricQuery{
 			FROM pg_stat_database
 			WHERE datname = current_database()
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "deadlocks",
 				Unit: "lock",
@@ -102,7 +102,7 @@ var postgresMetricQueries = []MetricQuery{
 			},
 		},
 	},
-	MetricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				COALESCE(SUM(seq_scan), 0) as seq_scan,
@@ -110,7 +110,7 @@ var postgresMetricQueries = []MetricQuery{
 				current_database() as dbname
 			FROM pg_stat_user_tables
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "seq_scan",
 				Unit: "scan",
@@ -121,28 +121,28 @@ var postgresMetricQueries = []MetricQuery{
 			},
 		},
 	},
-	MetricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				count(distinct pid) as blocked_connections
 			FROM pg_locks
 			WHERE granted = false
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "blocked_connections",
 				Unit: "conn",
 			},
 		},
 	},
-	MetricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				EXTRACT(epoch FROM MAX(now() - xact_start))::INT as max_tx_age
 			FROM pg_stat_activity
       WHERE state IN ('idle in transaction', 'active')
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{
 				Key:  "max_tx_age",
 				Unit: "s",

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo/fakebrokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/utils"
@@ -104,7 +105,7 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 			testDBConnectionString, nil,
 		)
 		By("Creating a new collector")
-		metricsCollector, err = metricsCollectorDriver.NewCollector("instance-guid1")
+		metricsCollector, err = metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Retrieving initial metrics")

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -105,7 +105,12 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 			testDBConnectionString, nil,
 		)
 		By("Creating a new collector")
-		metricsCollector, err = metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
+		metricsCollector, err = metricsCollectorDriver.NewCollector(
+			brokerinfo.InstanceInfo{
+				GUID: "instance-guid1",
+				Type: "postgres",
+			},
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Retrieving initial metrics")

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"regexp"
 	"sync"
 	"time"
 
@@ -368,62 +367,5 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		Expect(metric).ToNot(BeNil())
 		Expect(metric.Value).To(BeNumerically(">=", 1))
 		Expect(metric.Unit).To(Equal("s"))
-	})
-
-})
-
-func openMultipleDBConns(count int, driver, url string) func() {
-	var dbConns []*sql.DB
-	success := false
-
-	closeDBConns := func() {
-		for _, c := range dbConns {
-			c.Close()
-		}
-	}
-	defer func() {
-		if success != true {
-			closeDBConns()
-		}
-	}()
-
-	for i := 0; i < count; i++ {
-		dbConn, err := sql.Open(driver, url)
-		Expect(err).ToNot(HaveOccurred())
-		err = dbConn.Ping()
-		Expect(err).ToNot(HaveOccurred())
-		dbConns = append(dbConns, dbConn)
-	}
-	success = true
-	return closeDBConns
-}
-
-func getMetricByKey(collectedMetrics []metrics.Metric, key string) *metrics.Metric {
-	for _, metric := range collectedMetrics {
-		if metric.Key == key {
-			return &metric
-		}
-	}
-	return nil
-}
-
-// Replaces the DB name in a postgres DB connection string
-func injectDBName(connectionString, newDBName string) string {
-	re := regexp.MustCompile("(.*:[0-9]+)[^?]*([?].*)?$")
-	return re.ReplaceAllString(connectionString, fmt.Sprintf("$1/%s$2", newDBName))
-}
-
-var _ = Describe("injectDBName", func() {
-	It("replaces the db name", func() {
-		Expect(
-			injectDBName("postgresql://postgres@localhost:5432/foo?sslmode=disable", "mydb"),
-		).To(Equal(
-			"postgresql://postgres@localhost:5432/mydb?sslmode=disable",
-		))
-		Expect(
-			injectDBName("postgresql://postgres@localhost:5432?sslmode=disable", "mydb"),
-		).To(Equal(
-			"postgresql://postgres@localhost:5432/mydb?sslmode=disable",
-		))
 	})
 })

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -140,7 +140,8 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		By("Creating multiple new connections")
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		openMultipleDBConns(ctx, 20, "postgres", postgresTestDatabaseConnectionURL)
+		err, _ = openMultipleDBConns(ctx, 20, "postgres", postgresTestDatabaseConnectionURL)
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() float64 {
 			collectedMetrics, err = metricsCollector.Collect()

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -138,8 +138,9 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		initialConnections := metric.Value
 
 		By("Creating multiple new connections")
-		closeDBConns := openMultipleDBConns(20, "postgres", postgresTestDatabaseConnectionURL)
-		defer closeDBConns()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		openMultipleDBConns(ctx, 20, "postgres", postgresTestDatabaseConnectionURL)
 
 		Eventually(func() float64 {
 			collectedMetrics, err = metricsCollector.Collect()
@@ -153,7 +154,7 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 		)
 
 		By("Closing again the connections")
-		closeDBConns()
+		cancel()
 
 		Eventually(func() float64 {
 			collectedMetrics, err = metricsCollector.Collect()

--- a/pkg/collector/sql_collector.go
+++ b/pkg/collector/sql_collector.go
@@ -32,11 +32,11 @@ type sqlMetricsCollectorDriver struct {
 }
 
 // NewCollector ...
-func (d *sqlMetricsCollectorDriver) NewCollector(instanceGUID string) (MetricsCollector, error) {
-	url, err := d.brokerInfo.ConnectionString(instanceGUID)
+func (d *sqlMetricsCollectorDriver) NewCollector(instanceInfo brokerinfo.InstanceInfo) (MetricsCollector, error) {
+	url, err := d.brokerInfo.ConnectionString(instanceInfo)
 	if err != nil {
 		d.logger.Error("cannot compose connection string", err, lager.Data{
-			"instanceGUID": instanceGUID,
+			"instanceInfo": instanceInfo,
 		})
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (d *sqlMetricsCollectorDriver) NewCollector(instanceGUID string) (MetricsCo
 	dbConn, err := sql.Open(d.driver, url)
 	if err != nil {
 		d.logger.Error("cannot connect to the database", err, lager.Data{
-			"instanceGUID": instanceGUID,
+			"instanceInfo": instanceInfo,
 		})
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (d *sqlMetricsCollectorDriver) NewCollector(instanceGUID string) (MetricsCo
 	err = dbConn.Ping()
 	if err != nil {
 		d.logger.Error("cannot ping the database", err, lager.Data{
-			"instanceGUID": instanceGUID,
+			"instanceInfo": instanceInfo,
 		})
 		return nil, err
 	}

--- a/pkg/collector/sql_collector.go
+++ b/pkg/collector/sql_collector.go
@@ -70,6 +70,10 @@ func (d *sqlMetricsCollectorDriver) GetName() string {
 	return d.name
 }
 
+func (d *sqlMetricsCollectorDriver) SupportedTypes() []string {
+	return []string{d.name}
+}
+
 type sqlMetricsCollector struct {
 	queries []MetricQuery
 	dbConn  *sql.DB

--- a/pkg/collector/sql_collector_test.go
+++ b/pkg/collector/sql_collector_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo/fakebrokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
 )
@@ -89,7 +90,7 @@ var _ = Describe("sql_collector", func() {
 				"", fmt.Errorf("failure"),
 			)
 
-			_, err := metricsCollectorDriver.NewCollector("instance-guid1")
+			_, err := metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -106,7 +107,7 @@ var _ = Describe("sql_collector", func() {
 				"dummy", nil,
 			)
 
-			_, err := metricsCollectorDriver.NewCollector("instance-guid1")
+			_, err := metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("sql: unknown driver")))
 		})
@@ -123,7 +124,7 @@ var _ = Describe("sql_collector", func() {
 				"postgresql://postgres@localhost:3000?sslmode=disable", nil,
 			)
 
-			_, err := metricsCollectorDriver.NewCollector("instance-guid1")
+			_, err := metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("connect")))
 		})
@@ -140,7 +141,7 @@ var _ = Describe("sql_collector", func() {
 				postgresTestDatabaseConnectionURL, nil,
 			)
 
-			_, err := metricsCollectorDriver.NewCollector("instance-guid1")
+			_, err := metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -164,7 +165,7 @@ var _ = Describe("sql_collector", func() {
 				postgresTestDatabaseConnectionURL, nil,
 			)
 
-			collector, err = metricsCollectorDriver.NewCollector("instance-guid1")
+			collector, err = metricsCollectorDriver.NewCollector(brokerinfo.InstanceInfo{GUID: "instance-guid1"})
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/pkg/collector/sql_collector_test.go
+++ b/pkg/collector/sql_collector_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
 )
 
-var testQueries = []MetricQuery{
-	{
+var testQueries = []metricQuery{
+	&columnMetricQuery{
 		Query: `
 			SELECT
 				1::integer as foo,
@@ -25,36 +25,36 @@ var testQueries = []MetricQuery{
 				'val1' as tag1,
 				'val2' as tag2
 		`,
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{Key: "foo", Unit: "b"},
 			{Key: "bar", Unit: "s"},
 			{Key: "baz", Unit: "conn"},
 		},
 	},
-	{
+	&columnMetricQuery{
 		Query: "SELECT 1::integer as foo2",
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{Key: "foo2", Unit: "gauge"},
 		},
 	},
-	{
+	&columnMetricQuery{
 		Query: "SELECT 1::integer as foo",
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{Key: "powah", Unit: "gauge"},
 		},
 	},
-	{
+	&columnMetricQuery{
 		Query: "SELECT * FROM hell",
 	},
-	{
+	&columnMetricQuery{
 		Query: "SELECT 'Hello World' as foo2",
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{Key: "foo2", Unit: "gauge"},
 		},
 	},
-	{
+	&columnMetricQuery{
 		Query: "SELECT 1 AS foo WHERE 1 = 2",
-		Metrics: []MetricQueryMeta{
+		Metrics: []metricQueryMeta{
 			{Key: "foo", Unit: "gauge"},
 		},
 	},
@@ -311,36 +311,36 @@ var _ = Describe("helpers", func() {
 
 	})
 
-	Context("queryToMetrics()", func() {
+	Context("columnMetricQuery.getMetrics()", func() {
 		It("should error when query is missing a required key", func() {
-			_, err := queryToMetrics(dbConn, testQueries[2])
+			_, err := testQueries[2].getMetrics(dbConn)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("unable to find key")))
 		})
 
 		It("should error when query has syntax error", func() {
-			_, err := queryToMetrics(dbConn, testQueries[3])
+			_, err := testQueries[3].getMetrics(dbConn)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("unable to execute query")))
 		})
 
 		It("should error when query doesn't record float", func() {
-			_, err := queryToMetrics(dbConn, testQueries[4])
+			_, err := testQueries[4].getMetrics(dbConn)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("converting driver.Value type")))
 		})
 
 		It("should not error when query doesn't return any row", func() {
-			_, err := queryToMetrics(dbConn, testQueries[5])
+			_, err := testQueries[5].getMetrics(dbConn)
 
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should succeed to obtain metrics from query", func() {
-			rowMetrics, err := queryToMetrics(dbConn, testQueries[0])
+			rowMetrics, err := testQueries[0].getMetrics(dbConn)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(rowMetrics)).To(Equal(3))

--- a/pkg/collector/sql_collector_test.go
+++ b/pkg/collector/sql_collector_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
 )
 
-var testQueries = []metricQuery{
-	&columnMetricQuery{
+var testColumnQueries = map[string]metricQuery{
+	"multi_value": &columnMetricQuery{
 		Query: `
 			SELECT
 				1::integer as foo,
@@ -31,29 +31,126 @@ var testQueries = []metricQuery{
 			{Key: "baz", Unit: "conn"},
 		},
 	},
-	&columnMetricQuery{
+	"single_value": &columnMetricQuery{
 		Query: "SELECT 1::integer as foo2",
 		Metrics: []metricQueryMeta{
 			{Key: "foo2", Unit: "gauge"},
 		},
 	},
-	&columnMetricQuery{
+}
+
+var badColumnQueries = map[string]metricQuery{
+	"missing_key": &columnMetricQuery{
 		Query: "SELECT 1::integer as foo",
 		Metrics: []metricQueryMeta{
 			{Key: "powah", Unit: "gauge"},
 		},
 	},
-	&columnMetricQuery{
+	"invalid_query": &columnMetricQuery{
 		Query: "SELECT * FROM hell",
 	},
-	&columnMetricQuery{
+	"not_a_number": &columnMetricQuery{
 		Query: "SELECT 'Hello World' as foo2",
 		Metrics: []metricQueryMeta{
 			{Key: "foo2", Unit: "gauge"},
 		},
 	},
-	&columnMetricQuery{
+	"empty_query": &columnMetricQuery{
 		Query: "SELECT 1 AS foo WHERE 1 = 2",
+		Metrics: []metricQueryMeta{
+			{Key: "foo", Unit: "gauge"},
+		},
+	},
+}
+
+var testRowQueries = map[string]metricQuery{
+	"integer_value": &rowMetricQuery{
+		Query: `
+			SELECT
+				'foo' as key,
+				1::integer as value,
+				'val1' as tag1,
+				'val2' as tag2
+			UNION
+			SELECT
+				'Bar' as key,
+				2::integer as value,
+				'val1' as tag1,
+				'val2' as tag2
+			UNION
+			SELECT
+				'Ignored_value' as key,
+				2::integer as value,
+				'val1' as tag1,
+				'val2' as tag2
+		`,
+		Metrics: []metricQueryMeta{
+			{Key: "foo", Unit: "b"},
+			{Key: "bar", Unit: "s"},
+		},
+	},
+	"varchar_value": &rowMetricQuery{
+		Query: `
+			SELECT
+				'foo' as key,
+				'1'::varchar as value,
+				'val1' as tag1,
+				'val2' as tag2
+			UNION
+			SELECT
+				'Bar' as key,
+				'2'::varchar as value,
+				'val1' as tag1,
+				'val2' as tag2
+		`,
+		Metrics: []metricQueryMeta{
+			{Key: "foo", Unit: "b"},
+			{Key: "bar", Unit: "s"},
+		},
+	},
+	"double_value": &rowMetricQuery{
+		Query: `
+			SELECT
+				'foo' as key,
+				1::double precision as value,
+				'val1' as tag1,
+				'val2' as tag2
+			UNION
+			SELECT
+				'Bar' as key,
+				2::double precision as value,
+				'val1' as tag1,
+				'val2' as tag2
+		`,
+		Metrics: []metricQueryMeta{
+			{Key: "foo", Unit: "b"},
+			{Key: "bar", Unit: "s"},
+		},
+	},
+}
+
+var badRowQueries = map[string]metricQuery{
+	"missing_key": &rowMetricQuery{
+		Query: `
+			SELECT
+				'foo' as key,
+				1::integer as value
+		`,
+		Metrics: []metricQueryMeta{
+			{Key: "powah", Unit: "gauge"},
+		},
+	},
+	"invalid_query": &columnMetricQuery{
+		Query: "SELECT * FROM hell",
+	},
+	"not_a_number": &columnMetricQuery{
+		Query: "SELECT 'foo' as key, 'Hello World' as value",
+		Metrics: []metricQueryMeta{
+			{Key: "foo2", Unit: "gauge"},
+		},
+	},
+	"empty_query": &columnMetricQuery{
+		Query: "SELECT 'foo' as key, 1 as value WHERE 1 = 2",
 		Metrics: []metricQueryMeta{
 			{Key: "foo", Unit: "gauge"},
 		},
@@ -68,8 +165,13 @@ var _ = Describe("sql_collector", func() {
 	)
 	BeforeEach(func() {
 		brokerInfo = &fakebrokerinfo.FakeBrokerInfo{}
+
+		testColumnQueriesSlice := []metricQuery{}
+		for _, v := range testColumnQueries {
+			testColumnQueriesSlice = append(testColumnQueriesSlice, v)
+		}
 		metricsCollectorDriver = &sqlMetricsCollectorDriver{
-			queries:    testQueries,
+			queries:    testColumnQueriesSlice,
 			driver:     "postgres", // valid driver for testing
 			brokerInfo: brokerInfo,
 			name:       "sql",
@@ -189,10 +291,10 @@ var _ = Describe("sql_collector", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-
 })
 
-var _ = Describe("helpers", func() {
+var _ = Describe("metricQuery", func() {
+
 	var dbConn *sql.DB
 
 	BeforeEach(func() {
@@ -203,6 +305,93 @@ var _ = Describe("helpers", func() {
 
 	AfterEach(func() {
 		dbConn.Close()
+	})
+
+	Context("columnMetricQuery.getMetrics()", func() {
+		It("should error when query is missing a required key", func() {
+			_, err := badColumnQueries["missing_key"].getMetrics(dbConn)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(MatchRegexp("unable to find key")))
+		})
+
+		It("should error when query has syntax error", func() {
+			_, err := badColumnQueries["invalid_query"].getMetrics(dbConn)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(MatchRegexp("unable to execute query")))
+		})
+
+		It("should error when query doesn't record float", func() {
+			_, err := badColumnQueries["not_a_number"].getMetrics(dbConn)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(MatchRegexp("converting driver.Value type")))
+		})
+
+		It("should not error when query doesn't return any row", func() {
+			_, err := badColumnQueries["empty_query"].getMetrics(dbConn)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed to obtain metrics from query", func() {
+			rowMetrics, err := testColumnQueries["multi_value"].getMetrics(dbConn)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(rowMetrics)).To(Equal(3))
+			expectedTags := map[string]string{"source": "sql", "tag1": "val1", "tag2": "val2"}
+			Expect(rowMetrics).To(Equal([]metrics.Metric{
+				{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
+				{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},
+				{Key: "baz", Value: 3, Unit: "conn", Tags: expectedTags},
+			}))
+		})
+	})
+
+	Context("rowMetricQuery.getMetrics()", func() {
+		It("should error when query is missing a required key", func() {
+			_, err := badRowQueries["missing_key"].getMetrics(dbConn)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(MatchRegexp("unable to find key")))
+		})
+
+		It("should error when query has syntax error", func() {
+			_, err := badRowQueries["invalid_query"].getMetrics(dbConn)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(MatchRegexp("unable to execute query")))
+		})
+
+		It("should error when query doesn't record float", func() {
+			_, err := badRowQueries["not_a_number"].getMetrics(dbConn)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(MatchRegexp("converting driver.Value type")))
+		})
+
+		It("should not error when query doesn't return any row", func() {
+			_, err := badRowQueries["empty_query"].getMetrics(dbConn)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed to obtain metrics from query", func() {
+			for _, t := range []string{"integer_value", "varchar_value", "double_value"} {
+				By(fmt.Sprintf("Running a query that returns a %s typed value", t))
+
+				rowMetrics, err := testRowQueries[t].getMetrics(dbConn)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(rowMetrics)).To(Equal(2))
+				expectedTags := map[string]string{"source": "sql", "tag1": "val1", "tag2": "val2"}
+				Expect(rowMetrics).To(Equal([]metrics.Metric{
+					{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
+					{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},
+				}))
+			}
+		})
 	})
 
 	Context("getRowDataAsMaps()", func() {
@@ -311,45 +500,4 @@ var _ = Describe("helpers", func() {
 
 	})
 
-	Context("columnMetricQuery.getMetrics()", func() {
-		It("should error when query is missing a required key", func() {
-			_, err := testQueries[2].getMetrics(dbConn)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(MatchRegexp("unable to find key")))
-		})
-
-		It("should error when query has syntax error", func() {
-			_, err := testQueries[3].getMetrics(dbConn)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(MatchRegexp("unable to execute query")))
-		})
-
-		It("should error when query doesn't record float", func() {
-			_, err := testQueries[4].getMetrics(dbConn)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(MatchRegexp("converting driver.Value type")))
-		})
-
-		It("should not error when query doesn't return any row", func() {
-			_, err := testQueries[5].getMetrics(dbConn)
-
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should succeed to obtain metrics from query", func() {
-			rowMetrics, err := testQueries[0].getMetrics(dbConn)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(rowMetrics)).To(Equal(3))
-			expectedTags := map[string]string{"source": "sql", "tag1": "val1", "tag2": "val2"}
-			Expect(rowMetrics).To(Equal([]metrics.Metric{
-				{Key: "foo", Value: 1, Unit: "b", Tags: expectedTags},
-				{Key: "bar", Value: 2, Unit: "s", Tags: expectedTags},
-				{Key: "baz", Value: 3, Unit: "conn", Tags: expectedTags},
-			}))
-		})
-	})
 })

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alphagov/paas-rds-metric-collector/pkg/config"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/emitter"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/metrics"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/utils"
 )
 
 type workerID struct {
@@ -104,10 +105,12 @@ func (w *Scheduler) Start() error {
 
 		w.logger.Debug("refresh_instances", lager.Data{"instances": instanceInfos})
 		for _, instanceInfo := range instanceInfos {
-			for driverName := range w.metricsCollectorDrivers {
-				id := workerID{Driver: driverName, InstanceGUID: instanceInfo.GUID}
-				if !w.workerExists(id) {
-					w.startWorker(id, instanceInfo)
+			for driverName, driver := range w.metricsCollectorDrivers {
+				if utils.SliceContainsString(driver.SupportedTypes(), instanceInfo.Type) {
+					id := workerID{Driver: driverName, InstanceGUID: instanceInfo.GUID}
+					if !w.workerExists(id) {
+						w.startWorker(id, instanceInfo)
+					}
 				}
 			}
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -106,6 +106,7 @@ func NewScheduler(
 func (w *Scheduler) WithDriver(drivers ...collector.MetricsCollectorDriver) *Scheduler {
 	for _, driver := range drivers {
 		w.metricsCollectorDrivers[driver.GetName()] = driver
+		w.logger.Debug("registered_driver", lager.Data{"name": driver.GetName()})
 	}
 
 	return w

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -185,6 +185,11 @@ func (w *Scheduler) startWorker(id workerID, instanceInfo brokerinfo.InstanceInf
 			return
 		}
 
+		w.logger.Info("started_worker", lager.Data{
+			"driver":       id.Driver,
+			"instanceGUID": id.InstanceGUID,
+		})
+
 		newJob, err := scheduler.Every(w.metricCollectorInterval).Seconds().Run(func() {
 			w.logger.Debug("collecting metrics", lager.Data{
 				"driver":       id.Driver,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/brokerinfo/fakebrokerinfo"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/collector"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/config"
@@ -19,8 +20,8 @@ type fakeMetricsCollectorDriver struct {
 	mock.Mock
 }
 
-func (f *fakeMetricsCollectorDriver) NewCollector(instanceGUID string) (collector.MetricsCollector, error) {
-	args := f.Called(instanceGUID)
+func (f *fakeMetricsCollectorDriver) NewCollector(instanceInfo brokerinfo.InstanceInfo) (collector.MetricsCollector, error) {
+	args := f.Called(instanceInfo)
 	arg0 := args.Get(0)
 	if arg0 != nil {
 		return arg0.(collector.MetricsCollector), args.Error(1)
@@ -99,9 +100,9 @@ var _ = Describe("collector scheduler", func() {
 
 	It("should not schedule any worker if brokerinfo.ListInstanceGUIDs() fails", func() {
 		brokerInfo.On(
-			"ListInstanceGUIDs", mock.Anything,
+			"ListInstances", mock.Anything,
 		).Return(
-			[]string{}, fmt.Errorf("Error in ListInstanceGUIDs"),
+			[]brokerinfo.InstanceInfo{}, fmt.Errorf("Error in ListInstanceGUIDs"),
 		)
 
 		scheduler.Start()
@@ -116,9 +117,9 @@ var _ = Describe("collector scheduler", func() {
 
 	It("should check for new instances every 1 second", func() {
 		brokerInfo.On(
-			"ListInstanceGUIDs", mock.Anything,
+			"ListInstances", mock.Anything,
 		).Return(
-			[]string{}, nil,
+			[]brokerinfo.InstanceInfo{}, nil,
 		)
 
 		scheduler.Start()
@@ -131,9 +132,9 @@ var _ = Describe("collector scheduler", func() {
 
 	It("should not add a worker if fails creating a collector ", func() {
 		brokerInfo.On(
-			"ListInstanceGUIDs", mock.Anything,
+			"ListInstances", mock.Anything,
 		).Return(
-			[]string{"instance-guid1"}, nil,
+			[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
 		)
 		metricsCollectorDriver.On(
 			"NewCollector", mock.Anything,
@@ -153,9 +154,9 @@ var _ = Describe("collector scheduler", func() {
 
 	It("should not send metrics if the collector returns an error", func() {
 		brokerInfo.On(
-			"ListInstanceGUIDs", mock.Anything,
+			"ListInstances", mock.Anything,
 		).Return(
-			[]string{"instance-guid1"}, nil,
+			[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
 		)
 		metricsCollectorDriver.On(
 			"NewCollector", mock.Anything,
@@ -209,9 +210,9 @@ var _ = Describe("collector scheduler", func() {
 		It("should not add a worker if it fails scheduling the worker job", func() {
 			scheduler.metricCollectorInterval = 0 // Force the `scheduler` library to fail
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1"}, nil,
+				[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
 			)
 
 			scheduler.Start()
@@ -225,9 +226,9 @@ var _ = Describe("collector scheduler", func() {
 
 		It("should start one worker successfully when one instance exist", func() {
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1"}, nil,
+				[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
 			)
 
 			scheduler.Start()
@@ -251,9 +252,12 @@ var _ = Describe("collector scheduler", func() {
 
 		It("should start multiple workers successfully when multiple instance exist", func() {
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1", "instance-guid2"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+					{GUID: "instance-guid2"},
+				}, nil,
 			)
 
 			scheduler.Start()
@@ -288,9 +292,11 @@ var _ = Describe("collector scheduler", func() {
 
 		It("should add new workers when a new instance appears", func() {
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+				}, nil,
 			).Once()
 
 			scheduler.Start()
@@ -302,9 +308,12 @@ var _ = Describe("collector scheduler", func() {
 			)
 
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1", "instance-guid2"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+					{GUID: "instance-guid2"},
+				}, nil,
 			)
 
 			// Clear received envelopes
@@ -347,16 +356,21 @@ var _ = Describe("collector scheduler", func() {
 			)
 			// First loop returns 2 instances
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1", "instance-guid2"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+					{GUID: "instance-guid2"},
+				}, nil,
 			).Once()
 
 			// After return only one instance
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+				}, nil,
 			)
 
 			scheduler.Start()
@@ -390,9 +404,12 @@ var _ = Describe("collector scheduler", func() {
 
 		It("should stop the scheduler, workers and close collectors", func() {
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1", "instance-guid2"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+					{GUID: "instance-guid2"},
+				}, nil,
 			)
 
 			scheduler.Start()
@@ -412,7 +429,7 @@ var _ = Describe("collector scheduler", func() {
 			metricsCollector.AssertNumberOfCalls(GinkgoT(), "Close", 2)
 
 			Consistently(func() bool {
-				brokerInfo.AssertNumberOfCalls(GinkgoT(), "ListInstanceGUIDs", 1)
+				brokerInfo.AssertNumberOfCalls(GinkgoT(), "ListInstances", 1)
 				metricsCollectorDriver.AssertNumberOfCalls(GinkgoT(), "NewCollector", 2)
 				metricsCollector.AssertNumberOfCalls(GinkgoT(), "Collect", 2)
 				return true
@@ -421,9 +438,11 @@ var _ = Describe("collector scheduler", func() {
 
 		It("should stop the scheduler without any race condition", func() {
 			brokerInfo.On(
-				"ListInstanceGUIDs", mock.Anything,
+				"ListInstances", mock.Anything,
 			).Return(
-				[]string{"instance-guid1"}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1"},
+				}, nil,
 			)
 
 			metricsCollectorDriverNewCollectorCall.After(700 * time.Millisecond)
@@ -467,9 +486,11 @@ var _ = Describe("collector scheduler", func() {
 
 			It("should start one worker successfully when one driver works but other not", func() {
 				brokerInfo.On(
-					"ListInstanceGUIDs", mock.Anything,
+					"ListInstances", mock.Anything,
 				).Return(
-					[]string{"instance-guid1"}, nil,
+					[]brokerinfo.InstanceInfo{
+						{GUID: "instance-guid1"},
+					}, nil,
 				)
 				metricsCollectorDriver2.On(
 					"NewCollector", mock.Anything,
@@ -498,9 +519,11 @@ var _ = Describe("collector scheduler", func() {
 
 			It("Retries to create new collectors if one driver fails creating it once", func() {
 				brokerInfo.On(
-					"ListInstanceGUIDs", mock.Anything,
+					"ListInstances", mock.Anything,
 				).Return(
-					[]string{"instance-guid1"}, nil,
+					[]brokerinfo.InstanceInfo{
+						{GUID: "instance-guid1"},
+					}, nil,
 				)
 
 				metricsCollectorDriver2.On(
@@ -578,16 +601,21 @@ var _ = Describe("collector scheduler", func() {
 
 				// First loop returns 2 instances
 				brokerInfo.On(
-					"ListInstanceGUIDs", mock.Anything,
+					"ListInstances", mock.Anything,
 				).Return(
-					[]string{"instance-guid1", "instance-guid2"}, nil,
+					[]brokerinfo.InstanceInfo{
+						{GUID: "instance-guid1"},
+						{GUID: "instance-guid2"},
+					}, nil,
 				).Once()
 
 				// After return only one instance
 				brokerInfo.On(
-					"ListInstanceGUIDs", mock.Anything,
+					"ListInstances", mock.Anything,
 				).Return(
-					[]string{"instance-guid1"}, nil,
+					[]brokerinfo.InstanceInfo{
+						{GUID: "instance-guid1"},
+					}, nil,
 				)
 
 				scheduler.Start()
@@ -668,9 +696,11 @@ var _ = Describe("collector scheduler", func() {
 				)
 
 				brokerInfo.On(
-					"ListInstanceGUIDs", mock.Anything,
+					"ListInstances", mock.Anything,
 				).Return(
-					[]string{"instance-guid1"}, nil,
+					[]brokerinfo.InstanceInfo{
+						{GUID: "instance-guid1"},
+					}, nil,
 				)
 
 				metricsCollectorDriverNewCollectorCall.After(700 * time.Millisecond)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -35,6 +35,11 @@ func (f *fakeMetricsCollectorDriver) GetName() string {
 	return args.String(0)
 }
 
+func (f *fakeMetricsCollectorDriver) SupportedTypes() []string {
+	args := f.Called()
+	return args.Get(0).([]string)
+}
+
 type fakeMetricsCollector struct {
 	mock.Mock
 }
@@ -71,6 +76,7 @@ var _ = Describe("collector scheduler", func() {
 		metricsEmitter = &fakeMetricsEmitter{}
 		metricsCollectorDriver = &fakeMetricsCollectorDriver{}
 		metricsCollectorDriver.On("GetName").Return("fake")
+		metricsCollectorDriver.On("SupportedTypes").Return([]string{"fake"})
 		metricsCollector = &fakeMetricsCollector{}
 
 		scheduler = NewScheduler(
@@ -134,7 +140,9 @@ var _ = Describe("collector scheduler", func() {
 		brokerInfo.On(
 			"ListInstances", mock.Anything,
 		).Return(
-			[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
+			[]brokerinfo.InstanceInfo{
+				{GUID: "instance-guid1", Type: "fake"},
+			}, nil,
 		)
 		metricsCollectorDriver.On(
 			"NewCollector", mock.Anything,
@@ -156,7 +164,9 @@ var _ = Describe("collector scheduler", func() {
 		brokerInfo.On(
 			"ListInstances", mock.Anything,
 		).Return(
-			[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
+			[]brokerinfo.InstanceInfo{
+				{GUID: "instance-guid1", Type: "fake"},
+			}, nil,
 		)
 		metricsCollectorDriver.On(
 			"NewCollector", mock.Anything,
@@ -212,7 +222,9 @@ var _ = Describe("collector scheduler", func() {
 			brokerInfo.On(
 				"ListInstances", mock.Anything,
 			).Return(
-				[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1", Type: "fake"},
+				}, nil,
 			)
 
 			scheduler.Start()
@@ -228,7 +240,9 @@ var _ = Describe("collector scheduler", func() {
 			brokerInfo.On(
 				"ListInstances", mock.Anything,
 			).Return(
-				[]brokerinfo.InstanceInfo{{GUID: "instance-guid1"}}, nil,
+				[]brokerinfo.InstanceInfo{
+					{GUID: "instance-guid1", Type: "fake"},
+				}, nil,
 			)
 
 			scheduler.Start()
@@ -255,8 +269,8 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
-					{GUID: "instance-guid2"},
+					{GUID: "instance-guid1", Type: "fake"},
+					{GUID: "instance-guid2", Type: "fake"},
 				}, nil,
 			)
 
@@ -295,7 +309,7 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
+					{GUID: "instance-guid1", Type: "fake"},
 				}, nil,
 			).Once()
 
@@ -311,8 +325,8 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
-					{GUID: "instance-guid2"},
+					{GUID: "instance-guid1", Type: "fake"},
+					{GUID: "instance-guid2", Type: "fake"},
 				}, nil,
 			)
 
@@ -359,8 +373,8 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
-					{GUID: "instance-guid2"},
+					{GUID: "instance-guid1", Type: "fake"},
+					{GUID: "instance-guid2", Type: "fake"},
 				}, nil,
 			).Once()
 
@@ -369,7 +383,7 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
+					{GUID: "instance-guid1", Type: "fake"},
 				}, nil,
 			)
 
@@ -407,8 +421,8 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
-					{GUID: "instance-guid2"},
+					{GUID: "instance-guid1", Type: "fake"},
+					{GUID: "instance-guid2", Type: "fake"},
 				}, nil,
 			)
 
@@ -441,7 +455,7 @@ var _ = Describe("collector scheduler", func() {
 				"ListInstances", mock.Anything,
 			).Return(
 				[]brokerinfo.InstanceInfo{
-					{GUID: "instance-guid1"},
+					{GUID: "instance-guid1", Type: "fake"},
 				}, nil,
 			)
 
@@ -478,6 +492,7 @@ var _ = Describe("collector scheduler", func() {
 			BeforeEach(func() {
 				metricsCollectorDriver2 = &fakeMetricsCollectorDriver{}
 				metricsCollectorDriver2.On("GetName").Return("fake2")
+				metricsCollectorDriver2.On("SupportedTypes").Return([]string{"fake", "fake2"})
 				metricsCollector2 = &fakeMetricsCollector{}
 
 				scheduler.WithDriver(metricsCollectorDriver2)
@@ -489,7 +504,7 @@ var _ = Describe("collector scheduler", func() {
 					"ListInstances", mock.Anything,
 				).Return(
 					[]brokerinfo.InstanceInfo{
-						{GUID: "instance-guid1"},
+						{GUID: "instance-guid1", Type: "fake"},
 					}, nil,
 				)
 				metricsCollectorDriver2.On(
@@ -522,7 +537,7 @@ var _ = Describe("collector scheduler", func() {
 					"ListInstances", mock.Anything,
 				).Return(
 					[]brokerinfo.InstanceInfo{
-						{GUID: "instance-guid1"},
+						{GUID: "instance-guid1", Type: "fake"},
 					}, nil,
 				)
 
@@ -578,6 +593,63 @@ var _ = Describe("collector scheduler", func() {
 				)
 			})
 
+			It("should start only one worker for the supported types", func() {
+				brokerInfo.On(
+					"ListInstances", mock.Anything,
+				).Return(
+					[]brokerinfo.InstanceInfo{
+						{GUID: "instance-guid1", Type: "fake2"},
+					}, nil,
+				)
+				metricsCollectorDriver2.On(
+					"NewCollector", mock.Anything,
+				).Return(
+					metricsCollector2, nil,
+				)
+				metricsCollector2.On(
+					"Collect",
+				).Return(
+					[]metrics.Metric{
+						metrics.Metric{Key: "bar", Value: 3, Unit: "s"},
+					},
+					nil,
+				)
+
+				scheduler.Start()
+
+				Eventually(func() []string {
+					return scheduler.ListIntanceGUIDs()
+				}, 1*time.Second).Should(
+					HaveLen(1),
+				)
+				Consistently(func() []string {
+					return scheduler.ListIntanceGUIDs()
+				}, 2*time.Second).Should(
+					HaveLen(1),
+				)
+				Eventually(func() []metrics.MetricEnvelope {
+					return metricsEmitter.envelopesReceived
+				}, 2*time.Second).Should(
+					ContainElement(
+						metrics.MetricEnvelope{
+							InstanceGUID: "instance-guid1",
+							Metric:       metrics.Metric{Key: "bar", Value: 3.0, Unit: "s"},
+						},
+					),
+				)
+				Consistently(func() []metrics.MetricEnvelope {
+					return metricsEmitter.envelopesReceived
+				}, 2*time.Second).ShouldNot(
+					ContainElement(
+						metrics.MetricEnvelope{
+							InstanceGUID: "instance-guid1",
+							Metric:       metrics.Metric{Key: "foo", Value: 1.0, Unit: "b"},
+						},
+					),
+				)
+
+			})
+
 			It("should stop workers when one instance disappears", func() {
 				metricsCollectorDriver2.On(
 					"NewCollector", mock.Anything,
@@ -604,8 +676,8 @@ var _ = Describe("collector scheduler", func() {
 					"ListInstances", mock.Anything,
 				).Return(
 					[]brokerinfo.InstanceInfo{
-						{GUID: "instance-guid1"},
-						{GUID: "instance-guid2"},
+						{GUID: "instance-guid1", Type: "fake"},
+						{GUID: "instance-guid2", Type: "fake"},
 					}, nil,
 				).Once()
 
@@ -614,7 +686,7 @@ var _ = Describe("collector scheduler", func() {
 					"ListInstances", mock.Anything,
 				).Return(
 					[]brokerinfo.InstanceInfo{
-						{GUID: "instance-guid1"},
+						{GUID: "instance-guid1", Type: "fake"},
 					}, nil,
 				)
 
@@ -699,7 +771,7 @@ var _ = Describe("collector scheduler", func() {
 					"ListInstances", mock.Anything,
 				).Return(
 					[]brokerinfo.InstanceInfo{
-						{GUID: "instance-guid1"},
+						{GUID: "instance-guid1", Type: "fake"},
 					}, nil,
 				)
 

--- a/vendor/code.cloudfoundry.org/lager/json_redacter.go
+++ b/vendor/code.cloudfoundry.org/lager/json_redacter.go
@@ -1,0 +1,111 @@
+package lager
+
+import (
+	"encoding/json"
+	"regexp"
+)
+
+const awsAccessKeyIDPattern = `AKIA[A-Z0-9]{16}`
+const awsSecretAccessKeyPattern = `KEY["']?\s*(?::|=>|=)\s*["']?[A-Z0-9/\+=]{40}["']?`
+const cryptMD5Pattern = `\$1\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{22}`
+const cryptSHA256Pattern = `\$5\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{43}`
+const cryptSHA512Pattern = `\$6\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{86}`
+const privateKeyHeaderPattern = `-----BEGIN(.*)PRIVATE KEY-----`
+
+type JSONRedacter struct {
+	keyMatchers   []*regexp.Regexp
+	valueMatchers []*regexp.Regexp
+}
+
+func NewJSONRedacter(keyPatterns []string, valuePatterns []string) (*JSONRedacter, error) {
+	if keyPatterns == nil {
+		keyPatterns = []string{"[Pp]wd", "[Pp]ass"}
+	}
+	if valuePatterns == nil {
+		valuePatterns = []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
+	}
+	ret := &JSONRedacter{}
+	for _, v := range keyPatterns {
+		r, err := regexp.Compile(v)
+		if err != nil {
+			return nil, err
+		}
+		ret.keyMatchers = append(ret.keyMatchers, r)
+	}
+	for _, v := range valuePatterns {
+		r, err := regexp.Compile(v)
+		if err != nil {
+			return nil, err
+		}
+		ret.valueMatchers = append(ret.valueMatchers, r)
+	}
+	return ret, nil
+}
+
+func (r JSONRedacter) Redact(data []byte) []byte {
+	var jsonBlob interface{}
+	err := json.Unmarshal(data, &jsonBlob)
+	if err != nil {
+		return handleError(err)
+	}
+	r.redactValue(&jsonBlob)
+
+	data, err = json.Marshal(jsonBlob)
+	if err != nil {
+		return handleError(err)
+	}
+
+	return data
+}
+
+func (r JSONRedacter) redactValue(data *interface{}) interface{} {
+	if data == nil {
+		return data
+	}
+
+	if a, ok := (*data).([]interface{}); ok {
+		r.redactArray(&a)
+	} else if m, ok := (*data).(map[string]interface{}); ok {
+		r.redactObject(&m)
+	} else if s, ok := (*data).(string); ok {
+		for _, m := range r.valueMatchers {
+			if m.MatchString(s) {
+				(*data) = "*REDACTED*"
+				break
+			}
+		}
+	}
+	return (*data)
+}
+
+func (r JSONRedacter) redactArray(data *[]interface{}) {
+	for i, _ := range *data {
+		r.redactValue(&((*data)[i]))
+	}
+}
+
+func (r JSONRedacter) redactObject(data *map[string]interface{}) {
+	for k, v := range *data {
+		for _, m := range r.keyMatchers {
+			if m.MatchString(k) {
+				(*data)[k] = "*REDACTED*"
+				break
+			}
+		}
+		if (*data)[k] != "*REDACTED*" {
+			(*data)[k] = r.redactValue(&v)
+		}
+	}
+}
+
+func handleError(err error) []byte {
+	var content []byte
+	if _, ok := err.(*json.UnsupportedTypeError); ok {
+		data := map[string]interface{}{"lager serialisation error": err.Error()}
+		content, err = json.Marshal(data)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return content
+}

--- a/vendor/code.cloudfoundry.org/lager/logger.go
+++ b/vendor/code.cloudfoundry.org/lager/logger.go
@@ -77,8 +77,10 @@ func (l *logger) WithData(data Data) Logger {
 }
 
 func (l *logger) Debug(action string, data ...Data) {
+	t := time.Now().UTC()
 	log := LogFormat{
-		Timestamp: currentTimestamp(),
+		time:      t,
+		Timestamp: formatTimestamp(t),
 		Source:    l.component,
 		Message:   fmt.Sprintf("%s.%s", l.task, action),
 		LogLevel:  DEBUG,
@@ -91,8 +93,10 @@ func (l *logger) Debug(action string, data ...Data) {
 }
 
 func (l *logger) Info(action string, data ...Data) {
+	t := time.Now().UTC()
 	log := LogFormat{
-		Timestamp: currentTimestamp(),
+		time:      t,
+		Timestamp: formatTimestamp(t),
 		Source:    l.component,
 		Message:   fmt.Sprintf("%s.%s", l.task, action),
 		LogLevel:  INFO,
@@ -111,12 +115,15 @@ func (l *logger) Error(action string, err error, data ...Data) {
 		logData["error"] = err.Error()
 	}
 
+	t := time.Now().UTC()
 	log := LogFormat{
-		Timestamp: currentTimestamp(),
+		time:      t,
+		Timestamp: formatTimestamp(t),
 		Source:    l.component,
 		Message:   fmt.Sprintf("%s.%s", l.task, action),
 		LogLevel:  ERROR,
 		Data:      logData,
+		Error:     err,
 	}
 
 	for _, sink := range l.sinks {
@@ -137,12 +144,15 @@ func (l *logger) Fatal(action string, err error, data ...Data) {
 
 	logData["trace"] = string(stackTrace)
 
+	t := time.Now().UTC()
 	log := LogFormat{
-		Timestamp: currentTimestamp(),
+		time:      t,
+		Timestamp: formatTimestamp(t),
 		Source:    l.component,
 		Message:   fmt.Sprintf("%s.%s", l.task, action),
 		LogLevel:  FATAL,
 		Data:      logData,
+		Error:     err,
 	}
 
 	for _, sink := range l.sinks {
@@ -174,6 +184,6 @@ func (l *logger) baseData(givenData ...Data) Data {
 	return data
 }
 
-func currentTimestamp() string {
-	return fmt.Sprintf("%.9f", float64(time.Now().UnixNano())/1e9)
+func formatTimestamp(t time.Time) string {
+	return fmt.Sprintf("%.9f", float64(t.UnixNano())/1e9)
 }

--- a/vendor/code.cloudfoundry.org/lager/models.go
+++ b/vendor/code.cloudfoundry.org/lager/models.go
@@ -3,6 +3,9 @@ package lager
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type LogLevel int
@@ -14,7 +17,43 @@ const (
 	FATAL
 )
 
+var logLevelStr = [...]string{
+	DEBUG: "debug",
+	INFO:  "info",
+	ERROR: "error",
+	FATAL: "fatal",
+}
+
+func (l LogLevel) String() string {
+	if DEBUG <= l && l <= FATAL {
+		return logLevelStr[l]
+	}
+	return "invalid"
+}
+
+func LogLevelFromString(s string) (LogLevel, error) {
+	for k, v := range logLevelStr {
+		if v == s {
+			return LogLevel(k), nil
+		}
+	}
+	return -1, fmt.Errorf("invalid log level: %s", s)
+}
+
 type Data map[string]interface{}
+
+type rfc3339Time time.Time
+
+const rfc3339Nano = "2006-01-02T15:04:05.000000000Z07:00"
+
+func (t rfc3339Time) MarshalJSON() ([]byte, error) {
+	stamp := fmt.Sprintf(`"%s"`, time.Time(t).UTC().Format(rfc3339Nano))
+	return []byte(stamp), nil
+}
+
+func (t *rfc3339Time) UnmarshalJSON(data []byte) error {
+	return (*time.Time)(t).UnmarshalJSON(data)
+}
 
 type LogFormat struct {
 	Timestamp string   `json:"timestamp"`
@@ -22,18 +61,86 @@ type LogFormat struct {
 	Message   string   `json:"message"`
 	LogLevel  LogLevel `json:"log_level"`
 	Data      Data     `json:"data"`
+	Error     error    `json:"-"`
+	time      time.Time
 }
 
 func (log LogFormat) ToJSON() []byte {
 	content, err := json.Marshal(log)
 	if err != nil {
-		if _, ok := err.(*json.UnsupportedTypeError); ok {
-			log.Data = map[string]interface{}{"lager serialisation error": err.Error(), "data_dump": fmt.Sprintf("%#v", log.Data)}
-			content, err = json.Marshal(log)
-		}
+		log.Data = dataForJSONMarhallingError(err, log.Data)
+		content, err = json.Marshal(log)
 		if err != nil {
 			panic(err)
 		}
 	}
 	return content
+}
+
+func (log LogFormat) toPrettyJSON() []byte {
+	t := log.time
+	if t.IsZero() {
+		t = parseTimestamp(log.Timestamp)
+	}
+
+	prettyLog := struct {
+		Timestamp rfc3339Time `json:"timestamp"`
+		Level     string      `json:"level"`
+		Source    string      `json:"source"`
+		Message   string      `json:"message"`
+		Data      Data        `json:"data"`
+		Error     error       `json:"-"`
+	}{
+		Timestamp: rfc3339Time(t),
+		Level:     log.LogLevel.String(),
+		Source:    log.Source,
+		Message:   log.Message,
+		Data:      log.Data,
+		Error:     log.Error,
+	}
+
+	content, err := json.Marshal(prettyLog)
+
+	if err != nil {
+		prettyLog.Data = dataForJSONMarhallingError(err, prettyLog.Data)
+		content, err = json.Marshal(prettyLog)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return content
+}
+
+func dataForJSONMarhallingError(err error, data Data) Data {
+	_, ok1 := err.(*json.UnsupportedTypeError)
+	_, ok2 := err.(*json.MarshalerError)
+	errKey := "unknown_error"
+	if ok1 || ok2 {
+		errKey = "lager serialisation error"
+	}
+
+	return map[string]interface{}{
+		errKey:      err.Error(),
+		"data_dump": fmt.Sprintf("%#v", data),
+	}
+}
+
+func parseTimestamp(s string) time.Time {
+	if s == "" {
+		return time.Now()
+	}
+	n := strings.IndexByte(s, '.')
+	if n <= 0 || n == len(s)-1 {
+		return time.Now()
+	}
+	sec, err := strconv.ParseInt(s[:n], 10, 64)
+	if err != nil || sec < 0 {
+		return time.Now()
+	}
+	nsec, err := strconv.ParseInt(s[n+1:], 10, 64)
+	if err != nil || nsec < 0 {
+		return time.Now()
+	}
+	return time.Unix(sec, nsec)
 }

--- a/vendor/code.cloudfoundry.org/lager/redacting_writer_sink.go
+++ b/vendor/code.cloudfoundry.org/lager/redacting_writer_sink.go
@@ -1,0 +1,40 @@
+package lager
+
+import (
+	"io"
+	"sync"
+)
+
+type redactingWriterSink struct {
+	writer       io.Writer
+	minLogLevel  LogLevel
+	writeL       *sync.Mutex
+	jsonRedacter *JSONRedacter
+}
+
+func NewRedactingWriterSink(writer io.Writer, minLogLevel LogLevel, keyPatterns []string, valuePatterns []string) (Sink, error) {
+	jsonRedacter, err := NewJSONRedacter(keyPatterns, valuePatterns)
+	if err != nil {
+		return nil, err
+	}
+	return &redactingWriterSink{
+		writer:       writer,
+		minLogLevel:  minLogLevel,
+		writeL:       new(sync.Mutex),
+		jsonRedacter: jsonRedacter,
+	}, nil
+}
+
+func (sink *redactingWriterSink) Log(log LogFormat) {
+	if log.LogLevel < sink.minLogLevel {
+		return
+	}
+
+	sink.writeL.Lock()
+	v := log.ToJSON()
+	rv := sink.jsonRedacter.Redact(v)
+
+	sink.writer.Write(rv)
+	sink.writer.Write([]byte("\n"))
+	sink.writeL.Unlock()
+}

--- a/vendor/code.cloudfoundry.org/lager/writer_sink.go
+++ b/vendor/code.cloudfoundry.org/lager/writer_sink.go
@@ -36,3 +36,27 @@ func (sink *writerSink) Log(log LogFormat) {
 	sink.writer.Write([]byte("\n"))
 	sink.writeL.Unlock()
 }
+
+type prettySink struct {
+	writer      io.Writer
+	minLogLevel LogLevel
+	writeL      sync.Mutex
+}
+
+func NewPrettySink(writer io.Writer, minLogLevel LogLevel) Sink {
+	return &prettySink{
+		writer:      writer,
+		minLogLevel: minLogLevel,
+	}
+}
+
+func (sink *prettySink) Log(log LogFormat) {
+	if log.LogLevel < sink.minLogLevel {
+		return
+	}
+
+	sink.writeL.Lock()
+	sink.writer.Write(log.toPrettyJSON())
+	sink.writer.Write([]byte("\n"))
+	sink.writeL.Unlock()
+}

--- a/vendor/github.com/alphagov/paas-rds-broker/rdsbroker/broker.go
+++ b/vendor/github.com/alphagov/paas-rds-broker/rdsbroker/broker.go
@@ -629,6 +629,7 @@ func (b *RDSBroker) CheckAndRotateCredentials() {
 		}
 
 		err = sqlEngine.Open(dbDetails.Address, dbDetails.Port, dbName, dbDetails.MasterUsername, masterPassword)
+		sqlEngine.Close()
 
 		if err != nil {
 			if err == sqlengine.LoginFailedError {
@@ -639,14 +640,11 @@ func (b *RDSBroker) CheckAndRotateCredentials() {
 				err = b.dbInstance.Modify(dbDetails.Identifier, *dbDetails, true)
 				if err != nil {
 					b.logger.Error(fmt.Sprintf("Could not reset the master password of instance %v", dbDetails.Identifier), err)
-					continue
 				}
 			} else {
 				b.logger.Error(fmt.Sprintf("Unknown error when connecting to DB %v at %v", dbName, dbDetails.Address), err)
-				continue
 			}
 		}
-		defer sqlEngine.Close()
 	}
 	b.logger.Info(fmt.Sprintf("Instances credentials check has ended"))
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158946642

What?
-----

Now that we've got a pattern to obtain postgres metrics from RDS instances and the CloudWatch, we'd like to do the same for MySQL.

In this PR we had to refactor the code a little bit:

 - We extended the `scheduler` and `brokerinfo` packages to support different collectors depending on the instance type. For instance, there is one colector for mysql and other for postgres.
 - We extended the generic sql collector, to support two types of queries:
     - `columnMetricQuery` for queries that return one metric per column. This is more suitable for postgres.
      - `rowMetricQuery` for queries that return one metric per row. More suitable for mysql.

 - We enable both types mysql and postgres in the `ci/blackbox` test. We also reduce verbosity in these tests.
 -  Additionally we fixed some bug in the `scheduler` and updated some tests.

How to review?
--------------

 - Code review
 - Tests should pass
 - You can deploy this and check you get metrics from log-cache for a mysql instance.


Who?
----

Not me or @jpluscplusm 