### PR TITLE
[#159174667] Reduce CloudWatch costs

### DIFF
--- a/ci/blackbox/rds_metric_collector_suite_test.go
+++ b/ci/blackbox/rds_metric_collector_suite_test.go
@@ -14,12 +14,13 @@ import (
 	rdsconfig "github.com/alphagov/paas-rds-broker/config"
 	collectorconfig "github.com/alphagov/paas-rds-metric-collector/pkg/config"
 
+	"path"
+
+	"code.cloudfoundry.org/locket"
 	. "github.com/alphagov/paas-rds-broker/ci/helpers"
 	"github.com/alphagov/paas-rds-metric-collector/pkg/helpers"
 	"github.com/alphagov/paas-rds-metric-collector/testhelpers"
 	"github.com/onsi/gomega/gbytes"
-	"code.cloudfoundry.org/locket"
-	"path"
 )
 
 var (
@@ -110,8 +111,9 @@ func TestSuite(t *testing.T) {
 				MasterPasswordSeed: "something-secret",
 			},
 			Scheduler: collectorconfig.SchedulerConfig{
-				InstanceRefreshInterval: 30,
-				MetricCollectorInterval: 5,
+				InstanceRefreshInterval:    30,
+				SQLMetricCollectorInterval: 5,
+				CWMetricCollectorInterval:  5,
 			},
 			LoggregatorEmitter: collectorconfig.LoggregatorEmitterConfig{
 				MetronURL:  fakeLoggregator.Addr,

--- a/example_config.json
+++ b/example_config.json
@@ -10,7 +10,8 @@
 	},
 	"scheduler": {
 		"instance_refresh_interval": 120,
-		"metrics_collector_interval": 60
+		"sql_metrics_collector_interval": 180,
+		"cloudwatch_metrics_collector_interval": 300
 	},
 	"loggregator_emitter": {
 		"url": "localhost:3458",

--- a/fixtures/collector_config.json
+++ b/fixtures/collector_config.json
@@ -10,7 +10,8 @@
 	},
 	"scheduler": {
 		"instance_refresh_interval": 30,
-		"metrics_collector_interval": 5
+		"sql_metrics_collector_interval": 5,
+		"cloudwatch_metrics_collector_interval": 5
 	},
 	"loggregator_emitter": {
 		"url": "localhost:3458",

--- a/main.go
+++ b/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
 
 	_ "github.com/lib/pq"
 
@@ -97,16 +98,19 @@ func main() {
 	}
 
 	postgresMetricsCollectorDriver := collector.NewPostgresMetricsCollectorDriver(
+		cfg.Scheduler.SQLMetricCollectorInterval,
 		rdsBrokerInfo,
 		logger.Session("postgres_metrics_collector"),
 	)
 
 	mysqlMetricsCollectorDriver := collector.NewMysqlMetricsCollectorDriver(
+		cfg.Scheduler.SQLMetricCollectorInterval,
 		rdsBrokerInfo,
 		logger.Session("mysql_metrics_collector"),
 	)
 
 	cloudWatchMetricsCollectorDriver := collector.NewCloudWatchCollectorDriver(
+		cfg.Scheduler.CWMetricCollectorInterval,
 		awsSession,
 		rdsBrokerInfo,
 		logger.Session("cloudwatch_metrics_collector"),

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -17,28 +17,14 @@ import (
 )
 
 var metricNamesToLabels = map[string]string{
-	"CPUUtilization":            "cpu",
-	"CPUCreditUsage":            "cpu_credit_usage",
-	"CPUCreditBalance":          "cpu_credit_balance",
-	"FreeableMemory":            "freeable_memory",
-	"FreeStorageSpace":          "free_storage_space",
-	"SwapUsage":                 "swap_usage",
-	"NetworkReceiveThroughput":  "network_receive_rate",
-	"NetworkTransmitThroughput": "network_transmit_rate",
-	"DiskQueueDepth":            "disk_queue_depth",
-	"ReadIOPS":                  "read_iops",
-	"ReadLatency":               "read_latency",
-	"ReadThroughput":            "read_rate",
-	"WriteIOPS":                 "write_iops",
-	"WriteLatency":              "write_latency",
-	"WriteThroughput":           "write_rate",
-	// More fancy metrics
-	"ReplicaLag":                "replica_lag",
-	"ReplicationSlotDiskUsage":  "replica_slot_disk_usage",
-	"OldestReplicationSlotLag":  "replication_lag",
-	"MaximumUsedTransactionIDs": "max_used_transaction_ids",
-	"TransactionLogsDiskUsage":  "transaction_logs_disk_usage",
-	"TransactionLogsGeneration": "transaction_logs_generation",
+	"CPUUtilization":   "cpu",
+	"CPUCreditUsage":   "cpu_credit_usage",
+	"CPUCreditBalance": "cpu_credit_balance",
+	"FreeableMemory":   "freeable_memory",
+	"FreeStorageSpace": "free_storage_space",
+	"SwapUsage":        "swap_usage",
+	"ReadIOPS":         "read_iops",
+	"WriteIOPS":        "write_iops",
 }
 
 // NewCloudWatchCollectorDriver ...

--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -42,19 +42,21 @@ var metricNamesToLabels = map[string]string{
 }
 
 // NewCloudWatchCollectorDriver ...
-func NewCloudWatchCollectorDriver(session client.ConfigProvider, brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) *CloudWatchCollectorDriver {
+func NewCloudWatchCollectorDriver(intervalSeconds int, session client.ConfigProvider, brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) MetricsCollectorDriver {
 	return &CloudWatchCollectorDriver{
-		session:    session,
-		brokerInfo: brokerInfo,
-		logger:     logger,
+		collectInterval: intervalSeconds,
+		session:         session,
+		brokerInfo:      brokerInfo,
+		logger:          logger,
 	}
 }
 
 // CloudWatchCollectorDriver ...
 type CloudWatchCollectorDriver struct {
-	session    client.ConfigProvider
-	brokerInfo brokerinfo.BrokerInfo
-	logger     lager.Logger
+	collectInterval int
+	session         client.ConfigProvider
+	brokerInfo      brokerinfo.BrokerInfo
+	logger          lager.Logger
 }
 
 // NewCollector ...
@@ -73,6 +75,10 @@ func (cw *CloudWatchCollectorDriver) GetName() string {
 
 func (cw *CloudWatchCollectorDriver) SupportedTypes() []string {
 	return []string{"postgres", "mysql"}
+}
+
+func (cw *CloudWatchCollectorDriver) GetCollectInterval() int {
+	return cw.collectInterval
 }
 
 // CloudWatchCollector ...

--- a/pkg/collector/cloudwatch_collector_test.go
+++ b/pkg/collector/cloudwatch_collector_test.go
@@ -29,7 +29,7 @@ var _ = Describe("cloudwatch_collector", func() {
 			)
 
 			s := session.New()
-			metricsCollectorDriver = NewCloudWatchCollectorDriver(s, brokerInfo, logger)
+			metricsCollectorDriver = NewCloudWatchCollectorDriver(5, s, brokerInfo, logger)
 		})
 
 		It("should create a NewCollector successfully", func() {
@@ -41,6 +41,10 @@ var _ = Describe("cloudwatch_collector", func() {
 
 		It("shall return the name", func() {
 			Expect(metricsCollectorDriver.GetName()).To(Equal("cloudwatch"))
+		})
+
+		It("should return the CollectInterval", func() {
+			Expect(metricsCollectorDriver.GetCollectInterval()).To(Equal(5))
 		})
 	})
 

--- a/pkg/collector/metrics_collector.go
+++ b/pkg/collector/metrics_collector.go
@@ -10,6 +10,7 @@ type MetricsCollectorDriver interface {
 	NewCollector(instanceInfo brokerinfo.InstanceInfo) (MetricsCollector, error)
 	GetName() string
 	SupportedTypes() []string
+	GetCollectInterval() int
 }
 
 // MetricsCollector ...

--- a/pkg/collector/mysql_collector.go
+++ b/pkg/collector/mysql_collector.go
@@ -192,12 +192,13 @@ var mysqlMetricQueries = []metricQuery{
 }
 
 // NewMysqlMetricsCollectorDriver ...
-func NewMysqlMetricsCollectorDriver(brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) MetricsCollectorDriver {
+func NewMysqlMetricsCollectorDriver(intervalSeconds int, brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) MetricsCollectorDriver {
 	return &sqlMetricsCollectorDriver{
-		logger:     logger,
-		queries:    mysqlMetricQueries,
-		driver:     "mysql",
-		brokerInfo: brokerInfo,
-		name:       "mysql",
+		collectInterval: intervalSeconds,
+		logger:          logger,
+		queries:         mysqlMetricQueries,
+		driver:          "mysql",
+		brokerInfo:      brokerInfo,
+		name:            "mysql",
 	}
 }

--- a/pkg/collector/mysql_collector_test.go
+++ b/pkg/collector/mysql_collector_test.go
@@ -51,7 +51,7 @@ var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
 	BeforeEach(func() {
 		var err error
 		brokerInfo = &fakebrokerinfo.FakeBrokerInfo{}
-		metricsCollectorDriver = NewMysqlMetricsCollectorDriver(brokerInfo, logger)
+		metricsCollectorDriver = NewMysqlMetricsCollectorDriver(5, brokerInfo, logger)
 
 		brokerInfo.On(
 			"ConnectionString", mock.Anything,
@@ -75,6 +75,10 @@ var _ = Describe("NewMysqlMetricsCollectorDriver", func() {
 	AfterEach(func() {
 		err := metricsCollector.Close()
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return the CollectInterval", func() {
+		Expect(metricsCollectorDriver.GetCollectInterval()).To(Equal(5))
 	})
 
 	It("returns the right metricsCollectorDriver name", func() {

--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -152,12 +152,13 @@ var postgresMetricQueries = []metricQuery{
 }
 
 // NewPostgresMetricsCollectorDriver ...
-func NewPostgresMetricsCollectorDriver(brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) MetricsCollectorDriver {
+func NewPostgresMetricsCollectorDriver(intervalSeconds int, brokerInfo brokerinfo.BrokerInfo, logger lager.Logger) MetricsCollectorDriver {
 	return &sqlMetricsCollectorDriver{
-		logger:     logger,
-		queries:    postgresMetricQueries,
-		driver:     "postgres",
-		brokerInfo: brokerInfo,
-		name:       "postgres",
+		collectInterval: intervalSeconds,
+		logger:          logger,
+		queries:         postgresMetricQueries,
+		driver:          "postgres",
+		brokerInfo:      brokerInfo,
+		name:            "postgres",
 	}
 }

--- a/pkg/collector/postgres_collector_test.go
+++ b/pkg/collector/postgres_collector_test.go
@@ -96,7 +96,7 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 	BeforeEach(func() {
 		var err error
 		brokerInfo = &fakebrokerinfo.FakeBrokerInfo{}
-		metricsCollectorDriver = NewPostgresMetricsCollectorDriver(brokerInfo, logger)
+		metricsCollectorDriver = NewPostgresMetricsCollectorDriver(5, brokerInfo, logger)
 
 		brokerInfo.On(
 			"ConnectionString", mock.Anything,
@@ -120,6 +120,10 @@ var _ = Describe("NewPostgresMetricsCollectorDriver", func() {
 	AfterEach(func() {
 		err := metricsCollector.Close()
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return the CollectInterval", func() {
+		Expect(metricsCollectorDriver.GetCollectInterval()).To(Equal(5))
 	})
 
 	It("returns the right metricsCollectorDriver name", func() {

--- a/pkg/collector/sql_collector.go
+++ b/pkg/collector/sql_collector.go
@@ -18,11 +18,12 @@ type metricQuery interface {
 
 // sqlMetricsCollectorDriver pulls metrics using generic SQL queries
 type sqlMetricsCollectorDriver struct {
-	brokerInfo brokerinfo.BrokerInfo
-	queries    []metricQuery
-	driver     string
-	name       string
-	logger     lager.Logger
+	collectInterval int
+	brokerInfo      brokerinfo.BrokerInfo
+	queries         []metricQuery
+	driver          string
+	name            string
+	logger          lager.Logger
 }
 
 // NewCollector ...
@@ -66,6 +67,10 @@ func (d *sqlMetricsCollectorDriver) GetName() string {
 
 func (d *sqlMetricsCollectorDriver) SupportedTypes() []string {
 	return []string{d.name}
+}
+
+func (d *sqlMetricsCollectorDriver) GetCollectInterval() int {
+	return d.collectInterval
 }
 
 type sqlMetricsCollector struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,11 +12,11 @@ import (
 )
 
 type Config struct {
-	LogLevel                     string                   `json:"log_level" validate:"required"`
-	AWS                          AWSConfig                `json:"aws"`
-	RDSBrokerInfo                RDSBrokerInfoConfig      `json:"rds_broker"`
-	Scheduler                    SchedulerConfig          `json:"scheduler"`
-	LoggregatorEmitter           LoggregatorEmitterConfig `json:"loggregator_emitter"`
+	LogLevel           string                   `json:"log_level" validate:"required"`
+	AWS                AWSConfig                `json:"aws"`
+	RDSBrokerInfo      RDSBrokerInfoConfig      `json:"rds_broker"`
+	Scheduler          SchedulerConfig          `json:"scheduler"`
+	LoggregatorEmitter LoggregatorEmitterConfig `json:"loggregator_emitter"`
 	locket.ClientLocketConfig
 }
 
@@ -32,8 +32,9 @@ type RDSBrokerInfoConfig struct {
 }
 
 type SchedulerConfig struct {
-	InstanceRefreshInterval int `json:"instance_refresh_interval" validate:"required,gte=1,lte=3600"`
-	MetricCollectorInterval int `json:"metrics_collector_interval" validate:"required,gte=1,lte=3600"`
+	InstanceRefreshInterval    int `json:"instance_refresh_interval" validate:"required,gte=1,lte=3600"`
+	SQLMetricCollectorInterval int `json:"sql_metrics_collector_interval" validate:"required,gte=0,lte=3600"`
+	CWMetricCollectorInterval  int `json:"cloudwatch_metrics_collector_interval" validate:"required,gte=0,lte=3600"`
 }
 
 type LoggregatorEmitterConfig struct {
@@ -51,7 +52,8 @@ const defaultConfig = `
 	},
 	"scheduler": {
 		"instance_refresh_interval": 120,
-		"metrics_collector_interval": 60
+		"sql_metrics_collector_interval": 180,
+		"cloudwatch_metrics_collector_interval": 300
 	},
 	"loggregator_emitter": {
 		"url": "localhost:3458"

--- a/testhelpers/config.go
+++ b/testhelpers/config.go
@@ -1,12 +1,13 @@
 package testhelpers
 
 import (
-	"github.com/alphagov/paas-rds-metric-collector/pkg/config"
-	"code.cloudfoundry.org/locket"
-	"io/ioutil"
 	"encoding/json"
-	. "github.com/onsi/gomega"
+	"io/ioutil"
 	"path"
+
+	"code.cloudfoundry.org/locket"
+	"github.com/alphagov/paas-rds-metric-collector/pkg/config"
+	. "github.com/onsi/gomega"
 )
 
 func BuildTempConfigFile(locketAddress, fixturesPath string) (configFilePath string) {
@@ -22,8 +23,9 @@ func BuildTempConfigFile(locketAddress, fixturesPath string) (configFilePath str
 			MasterPasswordSeed: "something-secret",
 		},
 		Scheduler: config.SchedulerConfig{
-			InstanceRefreshInterval: 30,
-			MetricCollectorInterval: 5,
+			InstanceRefreshInterval:    30,
+			SQLMetricCollectorInterval: 5,
+			CWMetricCollectorInterval:  5,
 		},
 		LoggregatorEmitter: config.LoggregatorEmitterConfig{
 			MetronURL:  "localhost:3458",
@@ -47,4 +49,3 @@ func BuildTempConfigFile(locketAddress, fixturesPath string) (configFilePath str
 	Expect(err).ToNot(HaveOccurred())
 	return configFilePath
 }
-


### PR DESCRIPTION
## What

Currently, we're globally setting each driver with a value for how often
would it run the metric collection in seconds. This has proven to be
inefficient as CloudWatch metrics are being charged for "generously".

We'd like to collect CloudWatch metrics in a different rating to SQL
queries.

We've decided to concentrate on user needs as oppose to add all of the
metrics possible as these unfortunately cost us money.

## How to review

- Code review
- Test along with paas-cf
