### PR TITLE
[#159986104] Continue on with the remaining metrics on error

### DIFF
--- a/pkg/collector/cloudwatch_collector.go
+++ b/pkg/collector/cloudwatch_collector.go
@@ -99,7 +99,11 @@ func (cw *CloudWatchCollector) Collect() ([]metrics.Metric, error) {
 		})
 		data, err := cw.client.GetMetricStatistics(input)
 		if err != nil {
-			return nil, err
+			cw.logger.Error("querying cloudwatch metrics", err, lager.Data{
+				"metricName":   metricName,
+				"instanceGUID": cw.instance,
+			})
+			continue
 		}
 
 		cw.logger.Debug("GetMetricStatistics", lager.Data{

--- a/pkg/collector/cloudwatch_collector_test.go
+++ b/pkg/collector/cloudwatch_collector_test.go
@@ -61,14 +61,6 @@ var _ = Describe("cloudwatch_collector", func() {
 			}
 		})
 
-		It("should fail to Collect metrics due to invalid API response", func() {
-			fakeClient.GetMetricStatisticsReturns(nil, fmt.Errorf("__CONTROLLED_ERROR__"))
-
-			data, err := collector.Collect()
-			Expect(err).To(HaveOccurred())
-			Expect(data).To(BeNil())
-		})
-
 		It("should Collect metrics successfully", func() {
 			now := time.Now()
 			fakeClient.GetMetricStatisticsReturns(&cloudwatch.GetMetricStatisticsOutput{
@@ -100,6 +92,7 @@ var _ = Describe("cloudwatch_collector", func() {
 			Expect(data[0].Value).To(Equal(3.0))
 			Expect(data[0].Tags).To(HaveKeyWithValue("source", "cloudwatch"))
 		})
+
 		It("should preserve the timestamp", func() {
 			metricTime := time.Now().Add(-1 * time.Hour)
 
@@ -120,6 +113,28 @@ var _ = Describe("cloudwatch_collector", func() {
 			Expect(data).NotTo(BeEmpty())
 			Expect(data[0].Timestamp).To(Equal(metricTime.UnixNano()))
 		})
+
+		It("should continue to collect metrics when it hits an error", func() {
+			fakeClient.GetMetricStatisticsReturnsOnCall(0, nil, fmt.Errorf("__CONTROLLED_ERROR__"))
+			fakeClient.GetMetricStatisticsReturns(&cloudwatch.GetMetricStatisticsOutput{
+				Label: aws.String("test"),
+				Datapoints: []*cloudwatch.Datapoint{
+					&cloudwatch.Datapoint{
+						Timestamp: aws.Time(time.Now()),
+						Average:   aws.Float64(1),
+						Unit:      aws.String("Second"),
+					},
+				},
+			}, nil)
+			data, err := collector.Collect()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data).NotTo(BeNil())
+			Expect(data).NotTo(BeEmpty())
+			Expect(data[0].Unit).To(Equal("second"))
+			Expect(data[0].Value).To(Equal(1.0))
+			Expect(data[0].Tags).To(HaveKeyWithValue("source", "cloudwatch"))
+		})
+
 		It("should not fail if there are no datapoints", func() {
 			fakeClient.GetMetricStatisticsReturns(&cloudwatch.GetMetricStatisticsOutput{
 				Label:      aws.String("test"),


### PR DESCRIPTION
## What

At the current state, the for loop would stop the collection and return
error at any time when the error would occur.

This means, if the first metrics fails, due to timeout for instance,
none of the metric would be collected and dealt with.

Logging the error on the spot and not quitting, would assure these are
at least attempted and more errors would be printed to the log.

## How to review

- Code review
- Make sure the tests pass.

## Who

Anyone but me or @paroxp 