### PR TITLE
WIP: Inject the instance guid as a tag when emitting

### DIFF
--- a/pkg/emitter/loggregator.go
+++ b/pkg/emitter/loggregator.go
@@ -82,5 +82,6 @@ func (e *LoggregatorEmitter) Emit(me metrics.MetricEnvelope) {
 		loggregator.WithGaugeSourceInfo(me.InstanceGUID, "0"),
 		WithTimestamp(timestamp),
 		loggregator.WithEnvelopeTags(me.Metric.Tags),
+		loggregator.WithEnvelopeTags(map[string]string{"guid": me.InstanceGUID}),
 	)
 }

--- a/pkg/emitter/loggregator_test.go
+++ b/pkg/emitter/loggregator_test.go
@@ -218,5 +218,6 @@ var _ = Describe("IngressClient", func() {
 
 		Expect(envelope.GetTags()).To(HaveKeyWithValue("key1", "val1"))
 		Expect(envelope.GetTags()).To(HaveKeyWithValue("key2", "val2"))
+		Expect(envelope.GetTags()).To(HaveKeyWithValue("guid", "instance-guid"))
 	})
 })


### PR DESCRIPTION
What?
---

We found out that when using the firehose exporter[1], the instance
ID was not being added as a label of the metric being exported.

Instead, all the metrics from all the instances have the same labels
and we can not make any use of these metrics in prometheus.

In this commit we add a new tag "guid" that should be translated
to new label in prometheus

[1] https://github.com/bosh-prometheus/firehose_exporter

How to review?
-----

Code review

Who?
---

not me