### PR TITLE
Calculate max (system) transaction age as a float

### DIFF
--- a/pkg/collector/postgres_collector.go
+++ b/pkg/collector/postgres_collector.go
@@ -140,7 +140,7 @@ var postgresMetricQueries = []metricQuery{
 	&columnMetricQuery{
 		Query: `
 			SELECT
-				COALESCE(EXTRACT(epoch FROM MAX(now() - a.xact_start))::INT, 0) as max_tx_age
+				COALESCE(EXTRACT(epoch FROM MAX(now() - a.xact_start))::FLOAT, 0) as max_tx_age
 			FROM pg_stat_activity a
 			INNER JOIN pg_roles r ON r.rolname = a.usename
 			INNER JOIN pg_group g ON r.oid = ANY (g.grolist)
@@ -158,7 +158,7 @@ var postgresMetricQueries = []metricQuery{
 	&columnMetricQuery{
 		Query: `
 			SELECT
-				COALESCE(EXTRACT(epoch FROM MAX(now() - xact_start))::INT, 0) as max_system_tx_age
+				COALESCE(EXTRACT(epoch FROM MAX(now() - xact_start))::FLOAT, 0) as max_system_tx_age
 			FROM pg_stat_activity a
 			INNER JOIN pg_roles r ON r.rolname = a.usename
 			LEFT JOIN pg_group g ON r.oid = ANY (g.grolist)


### PR DESCRIPTION
What
---
Previous calculations lost precision by converting the number to an integer.
This resulted in the metric almost always being reported as 0 seconds to
tenants.

The metric in Prometheus is a decimal, so the change to a decimal here should
be handled by Prometheus.

How to review
---
1. Code review
2. Run the relevant paas-cf [branch](https://github.com/alphagov/paas-cf/pull/1936) down your pipeline
3. Introduce an artificially long transaction in a database (e.g. `accounts-db` in the billing space of the admin org) by opening a transaction, waiting, and closing it.
4. Validate that you can see decimal-precision timings like below

![image](https://user-images.githubusercontent.com/1747386/59109449-f8623080-8934-11e9-8751-cfdbaf7bfc9e.png)

Who can review
---
Not I