### PR TITLE
bump to golang 1.18

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,7 +1,7 @@
 name: Go
 on: [push, pull_request]
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 jobs:
 
   build:

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: "1.17"
+    tag: "1.18"
 inputs:
   - name: repo
     path: src/github.com/alphagov/paas-rds-metric-collector

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-rds-metric-collector
 
-go 1.17
+go 1.18
 
 require (
 	code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181929453

Match golang version used by the actual boshrelease that packages this.