### PR TITLE
BAU - Run tests with rds-broker 1.48.0

### DIFF
--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -23,7 +23,7 @@ run:
       update-ca-certificates
 
       cd "${GOPATH}/src/github.com/alphagov/paas-rds-metric-collector"
-      go install github.com/alphagov/paas-rds-broker@v1.14.0
+      go install github.com/alphagov/paas-rds-broker@v1.48.0
 
       # uncomment to debug grpc connections
       #export GRPC_GO_LOG_VERBOSITY_LEVEL=99


### PR DESCRIPTION
Description:
- Current version of the rds broker in production is 1.48.0 but we are running tests with an older version